### PR TITLE
Add option log-file

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -396,6 +396,8 @@ type flushSyncWriter interface {
 }
 
 func init() {
+	flag.StringVar(&logging.logDir, "log_dir", "", "If non-empty, write log files in this directory")
+	flag.StringVar(&logging.logFile, "log_file", "", "If non-empty, use this log file")
 	flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
 	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
 	flag.Var(&logging.verbosity, "v", "log level for V logs")
@@ -453,6 +455,14 @@ type loggingT struct {
 	// safely using atomic.LoadInt32.
 	vmodule   moduleSpec // The state of the -vmodule flag.
 	verbosity Level      // V logging level, the value of the -v flag/
+
+	// If non-empty, overrides the choice of directory in which to write logs.
+	// See createLogDirs for the full list of possible destinations.
+	logDir string
+
+	// If non-empty, specifies the path of the file to write logs. mutually exclusive
+	// with the log-dir option.
+	logFile string
 }
 
 // buffer holds a byte Buffer for reuse. The zero value is ready for use.

--- a/klog_file.go
+++ b/klog_file.go
@@ -20,7 +20,6 @@ package klog
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"os/user"
@@ -36,13 +35,9 @@ var MaxSize uint64 = 1024 * 1024 * 1800
 // logDirs lists the candidate directories for new log files.
 var logDirs []string
 
-// If non-empty, overrides the choice of directory in which to write logs.
-// See createLogDirs for the full list of possible destinations.
-var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
-
 func createLogDirs() {
-	if *logDir != "" {
-		logDirs = append(logDirs, *logDir)
+	if logging.logDir != "" {
+		logDirs = append(logDirs, logging.logDir)
 	}
 	logDirs = append(logDirs, os.TempDir())
 }
@@ -103,6 +98,13 @@ var onceLogDirs sync.Once
 // successfully, create also attempts to update the symlink for that tag, ignoring
 // errors.
 func create(tag string, t time.Time) (f *os.File, filename string, err error) {
+	if logging.logFile != "" {
+		f, err := os.Create(logging.logFile)
+		if err == nil {
+			return f, logging.logFile, nil
+		}
+		return nil, "", fmt.Errorf("log: unable to create log: %v", err)
+	}
 	onceLogDirs.Do(createLogDirs)
 	if len(logDirs) == 0 {
 		return nil, "", errors.New("log: no log dirs")


### PR DESCRIPTION
- Move all flag initialization to a single init() block
- add a new option `log-file`
- Avoid creating directories when `log-file` is specified

Change-Id: I76a79dcbcec0587f8056637577bf53ece370896a