### PR TITLE
Add SetLogger function to intercept klog output with logr

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -694,10 +694,13 @@ func (buf *buffer) someDigits(i, d int) int {
 
 func (l *loggingT) println(s severity, logr logr.InfoLogger, args ...interface{}) {
 	buf, file, line := l.header(s, 0)
-	fmt.Fprintln(buf, args...)
+	// if logr is set, we clear the generated header as we rely on the backing
+	// logr implementation to print headers
 	if logr != nil {
-		logr.Info(buf.String())
+		l.putBuffer(buf)
+		buf = l.getBuffer()
 	}
+	fmt.Fprintln(buf, args...)
 	l.output(s, logr, buf, file, line, false)
 }
 
@@ -707,6 +710,12 @@ func (l *loggingT) print(s severity, logr logr.InfoLogger, args ...interface{}) 
 
 func (l *loggingT) printDepth(s severity, logr logr.InfoLogger, depth int, args ...interface{}) {
 	buf, file, line := l.header(s, depth)
+	// if logr is set, we clear the generated header as we rely on the backing
+	// logr implementation to print headers
+	if logr != nil {
+		l.putBuffer(buf)
+		buf = l.getBuffer()
+	}
 	fmt.Fprint(buf, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
@@ -716,6 +725,12 @@ func (l *loggingT) printDepth(s severity, logr logr.InfoLogger, depth int, args 
 
 func (l *loggingT) printf(s severity, logr logr.InfoLogger, format string, args ...interface{}) {
 	buf, file, line := l.header(s, 0)
+	// if logr is set, we clear the generated header as we rely on the backing
+	// logr implementation to print headers
+	if logr != nil {
+		l.putBuffer(buf)
+		buf = l.getBuffer()
+	}
 	fmt.Fprintf(buf, format, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
@@ -728,6 +743,12 @@ func (l *loggingT) printf(s severity, logr logr.InfoLogger, format string, args 
 // will also appear in the log file unless --logtostderr is set.
 func (l *loggingT) printWithFileLine(s severity, logr logr.InfoLogger, file string, line int, alsoToStderr bool, args ...interface{}) {
 	buf := l.formatHeader(s, file, line)
+	// if logr is set, we clear the generated header as we rely on the backing
+	// logr implementation to print headers
+	if logr != nil {
+		l.putBuffer(buf)
+		buf = l.getBuffer()
+	}
 	fmt.Fprint(buf, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')

--- a/klog.go
+++ b/klog.go
@@ -773,6 +773,14 @@ func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
 	return rb.w.Write(bytes)
 }
 
+// SetLogger will set the backing logr implementation for klog.
+// If set, all log lines will be supressed from the regular Output, and
+// redirected to the logr implementation.
+// All log lines include the 'severity', 'file' and 'line' values attached as
+// structured logging values.
+// Use as:
+//   ...
+//   klog.SetLogger(zapr.NewLogger(zapLog))
 func SetLogger(logr logr.Logger) {
 	logging.logr = logr
 }
@@ -1164,10 +1172,10 @@ func newVerbose(level Level, b bool) Verbose {
 }
 
 // V reports whether verbosity at the call site is at least the requested level.
-// The returned value is a boolean of type Verbose, which implements Info, Infoln
+// The returned value is a struct of type Verbose, which implements Info, Infoln
 // and Infof. These methods will write to the Info log if called.
 // Thus, one may write either
-//	if klog.V(2) { klog.Info("log this") }
+//	if glog.V(2).Enabled() { klog.Info("log this") }
 // or
 //	klog.V(2).Info("log this")
 // The second form is shorter but the first is cheaper if logging is off because it does
@@ -1206,6 +1214,9 @@ func V(level Level) Verbose {
 	return newVerbose(level, false)
 }
 
+// Enabled will return true if this log level is enabled, guarded by the value
+// of v.
+// See the documentation of V for usage.
 func (v Verbose) Enabled() bool {
 	return v.enabled
 }

--- a/klog.go
+++ b/klog.go
@@ -816,23 +816,10 @@ func (l *loggingT) output(s severity, log logr.InfoLogger, buf *buffer, file str
 		}
 	}
 	data := buf.Bytes()
-	if l != nil {
+	if log != nil {
 		keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
 		if s == errorLog {
-			// if this is an Error log, we should be able to cast the
-			// InfoLogger to be a Logger and call the actual Error method on
-			// the backing logger.
-			// TODO: we probably shouldn't always assume this is the case, as
-			// it may not be in some implementations of go-logr.
-			// Instead, we could construct a fake Logger struct that's backed
-			// by the appropriate V levels InfoLogger that implements Error, so
-			// that we can always call Error if the severity is 'errorLog' and
-			// have the log line routed by the 'fake' Logger implementation.
-			if log, ok := log.(logr.Logger); ok {
-				log.Error(nil, string(data), keysAndValues...)
-			} else {
-				log.Info(string(data), keysAndValues...)
-			}
+			l.logr.Error(nil, string(data), keysAndValues...)
 		} else {
 			log.Info(string(data), keysAndValues...)
 		}

--- a/klog.go
+++ b/klog.go
@@ -817,11 +817,12 @@ func (l *loggingT) output(s severity, log logr.InfoLogger, buf *buffer, file str
 	}
 	data := buf.Bytes()
 	if log != nil {
-		keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
+		// TODO: set 'severity' and caller information as structured log info
+		// keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
 		if s == errorLog {
-			l.logr.Error(nil, string(data), keysAndValues...)
+			l.logr.Error(nil, string(data))
 		} else {
-			log.Info(string(data), keysAndValues...)
+			log.Info(string(data))
 		}
 	} else if l.toStderr {
 		os.Stderr.Write(data)

--- a/klog.go
+++ b/klog.go
@@ -809,7 +809,7 @@ func (l *loggingT) output(s severity, log logr.InfoLogger, buf *buffer, file str
 	}
 	data := buf.Bytes()
 	if l != nil {
-		keysAndValues := []interface{}{"severity", severityName[s]}
+		keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
 		if s == errorLog {
 			// if this is an Error log, we should be able to cast the
 			// InfoLogger to be a Logger and call the actual Error method on

--- a/klog_test.go
+++ b/klog_test.go
@@ -285,13 +285,13 @@ func TestVmoduleOn(t *testing.T) {
 	defer logging.swap(logging.newBuffers())
 	logging.vmodule.Set("klog_test=2")
 	defer logging.vmodule.Set("")
-	if !V(1) {
+	if !V(1).Enabled() {
 		t.Error("V not enabled for 1")
 	}
-	if !V(2) {
+	if !V(2).Enabled() {
 		t.Error("V not enabled for 2")
 	}
-	if V(3) {
+	if V(3).Enabled() {
 		t.Error("V enabled for 3")
 	}
 	V(2).Info("test")
@@ -310,7 +310,7 @@ func TestVmoduleOff(t *testing.T) {
 	logging.vmodule.Set("notthisfile=2")
 	defer logging.vmodule.Set("")
 	for i := 1; i <= 3; i++ {
-		if V(Level(i)) {
+		if V(Level(i)).Enabled() {
 			t.Errorf("V enabled for %d", i)
 		}
 	}
@@ -344,7 +344,7 @@ func testVmoduleGlob(pat string, match bool, t *testing.T) {
 	defer logging.swap(logging.newBuffers())
 	defer logging.vmodule.Set("")
 	logging.vmodule.Set(pat)
-	if V(2) != Verbose(match) {
+	if V(2).Enabled() != match {
 		t.Errorf("incorrect match for %q: got %t expected %t", pat, V(2), match)
 	}
 }

--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -150,7 +150,7 @@ func (l klogger) Info(msg string, kvList ...interface{}) {
 }
 
 func (l klogger) Enabled() bool {
-	return bool(klog.V(klog.Level(l.level)))
+	return bool(klog.V(klog.Level(l.level)).Enabled())
 }
 
 func (l klogger) Error(err error, msg string, kvList ...interface{}) {


### PR DESCRIPTION
This is an example of how we can modify klog and the work required in order to allow intercepting logs, including preserving the `V` level and severity.

In order to do this, I've had to change the type signature of `Verbose` from `type Verbose bool` to:

```
type Verbose struct {
	enabled bool
	logr    logr.InfoLogger
}
```

Consequently, it requires a corresponding change in k/k in the instances where `if klog.V(x) {` (replacing them with `if klog.V(x).Enabled()`).

The total changeset in k/k to get `bazel build //...` to pass:

```
 pkg/cloudprovider/providers/gce/cloud/gen.go                | 160 +++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------------------------
 pkg/cloudprovider/providers/vsphere/vclib/connection.go     |   2 +-
 pkg/controller/nodelifecycle/node_lifecycle_controller.go   |   4 +--
 pkg/controller/volume/attachdetach/reconciler/reconciler.go |   6 ++--
 pkg/kubectl/cmd/util/helpers.go                             |   2 +-
 pkg/kubelet/eviction/helpers.go                             |   4 +--
 pkg/proxy/endpoints.go                                      |   2 +-
 pkg/scheduler/algorithm/predicates/predicates.go            |   8 ++---
 pkg/scheduler/algorithm/priorities/interpod_affinity.go     |   2 +-
 pkg/scheduler/algorithm/priorities/resource_allocation.go   |   2 +-
 pkg/scheduler/algorithm/priorities/resource_limits.go       |   2 +-
 pkg/scheduler/algorithm/priorities/selector_spreading.go    |   2 +-
 pkg/scheduler/core/generic_scheduler.go                     |   6 ++--
 plugin/pkg/auth/authorizer/rbac/rbac.go                     |   2 +-
 staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go  |   4 +--
 staging/src/k8s.io/apiserver/pkg/util/trace/trace.go        |   4 +--
 staging/src/k8s.io/client-go/rest/request.go                |   8 ++---
 staging/src/k8s.io/client-go/transport/round_trippers.go    |   8 ++---
 18 files changed, 114 insertions(+), 114 deletions(-)
```

We can still preserve the old behaviour in the `k8s.io/klog/glog` package, for those that are using the dep `replace` method to implement glog.

ref #19