### PR TITLE
Add go_import_path option to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+go_import_path: k8s.io/klog
 dist: xenial
 go:
   - 1.9.x


### PR DESCRIPTION
In CI right now, `k8s.io/klog` is being fetched at `master` when `k8s.io/klog/glog` is tested, as it imports `k8s.io/klog`.

Travis supports setting a custom path to clone your repo at for exactly this reason, and this PR adds the option to the .travis.yml file 😄 

(see #20 for an example)