### PR TITLE
Adds link to k8s/community logging conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ How to use klog
 - You can now use `log-file` instead of `log-dir` for logging to a single file (See `examples/log_file/usage_log_file.go`)
 - If you want to redirect everything logged using klog somewhere else (say syslog!), you can use `klog.SetOutput()` method and supply a `io.Writer`. (See `examples/set_output/usage_set_output.go`)
 - Another pattern you can use is `k8s.io/klog/glog` which is a proxy that implements the older `glog` API with `dep` override (or fixing up just imports)
-
+- For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md))
 
 ### Coexisting with glog
 This package can be used side by side with glog. [This example](examples/coexist_glog/coexist_glog.go) shows how to initialize and syncronize flags from the global `flag.CommandLine` FlagSet. In addition, the example makes use of stderr as combined output by setting `alsologtostderr` (or `logtostderr`) to `true`.


### PR DESCRIPTION
**What this PR does / why we need it**:
Per @dims comment https://github.com/kubernetes/community/pull/3016 this adds a link to the logging conventions on k8s/community.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #28

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
Adds link to the README.md about logging conventions
```

Signed-off-by: Christopher Hein <me@christopherhein.com>