### PR TITLE
stderrthreshold is useless if logtostderr is set

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -739,7 +739,9 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 	}
 	data := buf.Bytes()
 	if l.toStderr {
-		os.Stderr.Write(data)
+		if s >= l.stderrThreshold.get() {
+			os.Stderr.Write(data)
+		}
 	} else {
 		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {
 			os.Stderr.Write(data)


### PR DESCRIPTION
stderrthreshold is useless if logtostderr is set.
This pr can ignore logs which log level is under stderrthreshold.
Like:
flag.Set("logtostderr","true")
flag.Set("stderrthreshold","ERROR")

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The flag "stderrthreshold" will take effect if flag "logtostderr" is set to "true".
In previous version, it will print all level logs whatever "stderrthreshold" is set.
```