### PR TITLE
Clearify that loglevel is expressed with integers

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -412,7 +412,7 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.StringVar(&logging.logFile, "log_file", "", "If non-empty, use this log file")
 	flagset.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
 	flagset.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
-	flagset.Var(&logging.verbosity, "v", "log level for V logs")
+	flagset.Var(&logging.verbosity, "v", "number for the log level verbosity")
 	flagset.BoolVar(&logging.skipHeaders, "skip_headers", false, "If true, avoid header prefixes in the log messages")
 	flagset.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
 	flagset.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR make clear that the verbosity is depending on integers not on string like (debug, info, etc)

**Which issue(s) this PR fixes** 
Fixes https://github.com/kubernetes/kubernetes/issues/35054
**Release note**:
```release-note
document and clarify more kubectl --v
```