### PR TITLE
go-logr link missing protocol

### DIFF
--- a/klogr/README.md
+++ b/klogr/README.md
@@ -1,6 +1,6 @@
 # Minimal Go logging using klog
 
-This package implements the [logr interface](github.com/go-logr/logr)
+This package implements the [logr interface](https://github.com/go-logr/logr)
 in terms of Kubernetes' [klog](https://github.com/kubernetes/klog).  This
 provides a relatively minimalist API to logging in Go, backed by a well-proven
 implementation.


### PR DESCRIPTION
**What this PR does / why we need it**:
The link in the `klogr` sub directory didn't have the protocol so the link 404'ed with - https://github.com/kubernetes/klog/blob/master/klogr/github.com/go-logr/logr 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

N/A

**Release note**:
```release-note
NONE
```

Signed-off-by: Christopher Hein <me@christopherhein.com>