### PR TITLE
klogr: Fix handling of duplicate key/values & add unit tests

### DIFF
--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -59,24 +59,45 @@ func framesToCaller() int {
 	return 1 // something went wrong, this is safe
 }
 
+// trimDuplicates will deduplicates elements provided in multiple KV tuple
+// slices, whilst maintaining the distinction between where the items are
+// contained.
 func trimDuplicates(kvLists ...[]interface{}) [][]interface{} {
+	// maintain a map of all seen keys
 	seenKeys := map[interface{}]struct{}{}
+	// build the same number of output slices as inputs
 	outs := make([][]interface{}, len(kvLists))
-	for i := len(kvLists)-1; i >= 0; i-- {
+	// iterate over the input slices backwards, as 'later' kv specifications
+	// of the same key will take precedence over earlier ones
+	for i := len(kvLists) - 1; i >= 0; i-- {
+		// initialise this output slice
 		outs[i] = []interface{}{}
+		// obtain a reference to the kvList we are processing
 		kvList := kvLists[i]
 
-		// TODO: handle odd-length kvLists
-		for i2 := len(kvList) - 2; i2 >= 0; i2 -= 2 {
+		// start iterating at len(kvList) - 2 (i.e. the 2nd last item) for
+		// slices that have an even number of elements.
+		// We add (len(kvList) % 2) here to handle the case where there is an
+		// odd number of elements in a kvList.
+		// If there is an odd number, then the last element in the slice will
+		// have the value 'null'.
+		for i2 := len(kvList) - 2 + (len(kvList) % 2); i2 >= 0; i2 -= 2 {
 			k := kvList[i2]
+			// if we have already seen this key, do not include it again
 			if _, ok := seenKeys[k]; ok {
 				continue
 			}
+			// make a note that we've observed a new key
 			seenKeys[k] = struct{}{}
+			// attempt to obtain the value of the key
 			var v interface{}
+			// i2+1 should only ever be out of bounds if we handling the first
+			// iteration over a slice with an odd number of elements
 			if i2+1 < len(kvList) {
 				v = kvList[i2+1]
 			}
+			// add this KV tuple to the *start* of the output list to maintain
+			// the original order as we are iterating over the slice backwards
 			outs[i] = append([]interface{}{k, v}, outs[i]...)
 		}
 	}

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -65,8 +65,20 @@ func TestInfo(t *testing.T) {
 			expectedOutput: ` "level"=4 "msg"="test"  
 `,
 		},
+		"should correctly handle odd-numbers of KVs": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue" "akey2"=null
+`,
+		},
+		"should correctly handle odd-numbers of KVs in both log values and Info args": {
+			klogr:         New().WithValues("basekey1", "basevar1", "basekey2"),
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
+			expectedOutput: ` "level"=0 "msg"="test" "basekey1"="basevar1" "basekey2"=null "akey"="avalue" "akey2"=null
+`,
+		},
 	}
-
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
 			klogr := test.klogr

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -1,0 +1,91 @@
+package klogr
+
+import (
+	"bytes"
+	"flag"
+	"testing"
+
+	"k8s.io/klog"
+
+	"github.com/go-logr/logr"
+)
+
+func TestInfo(t *testing.T) {
+	klog.InitFlags(nil)
+	flag.CommandLine.Set("v", "10")
+	flag.CommandLine.Set("skip_headers", "true")
+	flag.CommandLine.Set("logtostderr", "false")
+	flag.CommandLine.Set("alsologtostderr", "false")
+	flag.Parse()
+
+	tests := map[string]struct {
+		klogr          logr.InfoLogger
+		text           string
+		keysAndValues  []interface{}
+		expectedOutput string
+	}{
+		"should log with values passed to keysAndValues": {
+			klogr:         New().V(0),
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue"
+`,
+		},
+		"should print duplicate keys with the same value": {
+			klogr:         New().V(0),
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue" "akey"="avalue"
+`,
+		},
+		"should print duplicate keys with different values when all values are passed to Info": {
+			klogr:         New().V(0),
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue" "akey"="avalue2"
+`,
+		},
+		"should print duplicate keys with the same value when one is set on logger": {
+			klogr:         New().WithValues("akey", "avalue"),
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: ` "level"=0 "msg"="test" "akey"="avalue" "akey"="avalue"
+`,
+		},
+		"should print duplicate keys with different values when one is set on logger": {
+			klogr:         New().WithValues("akey", "avalue"),
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue2"},
+			expectedOutput: ` "level"=0 "msg"="test" "akey"="avalue" "akey"="avalue2"
+`,
+		},
+		"should print different log level if set": {
+			klogr: New().V(4),
+			text:  "test",
+			expectedOutput: ` "level"=4 "msg"="test"  
+`,
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			klogr := test.klogr
+			if klogr == nil {
+				klogr = New()
+			}
+
+			// hijack the klog output
+			tmpWriteBuffer := bytes.NewBuffer(nil)
+			klog.SetOutput(tmpWriteBuffer)
+
+			klogr.Info(test.text, test.keysAndValues...)
+			// call Flush to ensure the text isn't still buffered
+			klog.Flush()
+
+			actual := tmpWriteBuffer.String()
+			if actual != test.expectedOutput {
+				t.Errorf("expected %q did not match actual %q", test.expectedOutput, actual)
+			}
+		})
+	}
+}

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -31,32 +31,32 @@ func TestInfo(t *testing.T) {
 			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue"
 `,
 		},
-		"should print duplicate keys with the same value": {
+		"should not print duplicate keys with the same value": {
 			klogr:         New().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue" "akey"="avalue"
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue"
 `,
 		},
-		"should print duplicate keys with different values when all values are passed to Info": {
+		"should only print the last duplicate key when the values are passed to Info": {
 			klogr:         New().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue" "akey"="avalue2"
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue2"
 `,
 		},
-		"should print duplicate keys with the same value when one is set on logger": {
+		"should only print the duplicate key that is passed to Info if one was passed to the logger": {
 			klogr:         New().WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
-			expectedOutput: ` "level"=0 "msg"="test" "akey"="avalue" "akey"="avalue"
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue"
 `,
 		},
-		"should print duplicate keys with different values when one is set on logger": {
+		"should only print the key passed to Info when one is already set on the logger": {
 			klogr:         New().WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue2"},
-			expectedOutput: ` "level"=0 "msg"="test" "akey"="avalue" "akey"="avalue2"
+			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue2"
 `,
 		},
 		"should print different log level if set": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds 6 unit tests to cover some basic functionality of klogr's structured output handling.

I created these tests as I've noticed a bug in the 'deduplication' handling when multiple kv pairs with the same key are specified.

Output:

```
--- FAIL: TestInfo (0.00s)
    --- PASS: TestInfo/should_print_different_log_level_if_set (0.00s)
    --- PASS: TestInfo/should_log_with_values_passed_to_keysAndValues (0.00s)
    --- PASS: TestInfo/should_print_duplicate_keys_with_the_same_value (0.00s)
    --- FAIL: TestInfo/should_print_duplicate_keys_with_different_values_when_all_values_are_passed_to_Info (0.00s)
        klogr_test.go:86: expected " \"level\"=0 \"msg\"=\"test\"  \"akey\"=\"avalue\" \"akey\"=\"avalue2\"\n" did not match actual " \"level\"=0 \"msg\"=\"test\"  \"akey\"=\"avalue2\" \"akey\"=\"avalue2\"\n"
    --- PASS: TestInfo/should_print_duplicate_keys_with_the_same_value_when_one_is_set_on_logger (0.00s)
    --- PASS: TestInfo/should_print_duplicate_keys_with_different_values_when_one_is_set_on_logger (0.00s)
```

**Special notes for your reviewer**:

~The `should_print_duplicate_keys_with_different_values_when_all_values_are_passed_to_Info` test is failing - should I fix the actual implementation as part of this PR?~

~As you can see, the 2nd value is *always* set even if the two tuples have different values: `\"akey\"=\"avalue2\" \"akey\"=\"avalue2\"` (notice that `avalue2` is set twice)~

I've updated this PR to include handling of duplicate key/value tuples as well, so all the tests should now pass 😄 

**Release note**:
```release-note
NONE
```

/cc @dims @thockin @pohly 