### PR TITLE
Open existing log files with O_APPEND at startup

### DIFF
--- a/klog_file.go
+++ b/klog_file.go
@@ -97,9 +97,11 @@ var onceLogDirs sync.Once
 // contains tag ("INFO", "FATAL", etc.) and t.  If the file is created
 // successfully, create also attempts to update the symlink for that tag, ignoring
 // errors.
-func create(tag string, t time.Time) (f *os.File, filename string, err error) {
+// The startup argument indicates whether this is the initial startup of klog.
+// If startup is true, existing files are opened for apending instead of truncated.
+func create(tag string, t time.Time, startup bool) (f *os.File, filename string, err error) {
 	if logging.logFile != "" {
-		f, err := os.Create(logging.logFile)
+		f, err := openOrCreate(logging.logFile, startup)
 		if err == nil {
 			return f, logging.logFile, nil
 		}
@@ -113,7 +115,7 @@ func create(tag string, t time.Time) (f *os.File, filename string, err error) {
 	var lastErr error
 	for _, dir := range logDirs {
 		fname := filepath.Join(dir, name)
-		f, err := os.Create(fname)
+		f, err := openOrCreate(fname, startup)
 		if err == nil {
 			symlink := filepath.Join(dir, link)
 			os.Remove(symlink)        // ignore err
@@ -123,4 +125,15 @@ func create(tag string, t time.Time) (f *os.File, filename string, err error) {
 		lastErr = err
 	}
 	return nil, "", fmt.Errorf("log: cannot create log: %v", lastErr)
+}
+
+// The startup argument indicates whether this is the initial startup of klog.
+// If startup is true, existing files are opened for appending instead of truncated.
+func openOrCreate(name string, startup bool) (*os.File, error) {
+	if startup {
+		f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		return f, err
+	}
+	f, err := os.Create(name)
+	return f, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

klog shouldn't erase old log files when components restart,
and should also ensure it doesn't overwrite old logs in
existing files when restarts happen.

Previously, files were opened with O_TRUNC at both startup
and rotation time. While, in the latter case, this ensures
a fresh log file, it doesn't make sense in the former case.

We probably don't see this cause issues in many production environments these days because journald is a very popular log sink. @yujuhong also noticed some logs overwritten at the beginning in Windows tests, which may have been caused by klog not opening the files as append-only (to be clear, it seems that the files on Windows weren't truncated correctly either, which requires further research figure out).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Existing log files are now opened with O_APPEND at startup, instead of O_TRUNC. Rotation still uses O_TRUNC.
```

@dims @liggitt @yujuhong @pjh 