### PR TITLE
Revert default changes

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -43,7 +43,7 @@
 //		Logs are written to standard error instead of to files.
 //	-alsologtostderr=false
 //		Logs are written to standard error as well as to files.
-//	-stderrthreshold=INFO
+//	-stderrthreshold=ERROR
 //		Log events at or above this severity are logged to standard
 //		error as well as to files.
 //	-log_dir=""
@@ -396,8 +396,8 @@ type flushSyncWriter interface {
 }
 
 func init() {
-	// Default stderrThreshold is INFO.
-	logging.stderrThreshold = infoLog
+	// Default stderrThreshold is ERROR.
+	logging.stderrThreshold = errorLog
 
 	logging.setVState(0, nil, false)
 	go logging.flushDaemon()

--- a/klog.go
+++ b/klog.go
@@ -739,9 +739,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 	}
 	data := buf.Bytes()
 	if l.toStderr {
-		if s >= l.stderrThreshold.get() {
-			os.Stderr.Write(data)
-		}
+		os.Stderr.Write(data)
 	} else {
 		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {
 			os.Stderr.Write(data)


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts recent, potentially breaking changes to flag defaults. These block vendoring the latest version of klog into upstream Kubernetes, because they could break user deployments of core Kubernetes components. If these changes are eventually included, they need to be included in a way that respects the upstream deprecation policy (see below).

This PR reverts three other PRs:
1. #42, which changes the stderrthreshold default to INFO
    - This could cause significant, unexpected increases in logging verbosity.
2. ~#39, which changes the logtostderr default to true~
    - ~This, especially, could break existing logging configurations because when set, it disables logs from being sent to files, even if --log_file is set.~ EDIT: See below conversation, we decided to keep #39 due to pre-existing overrides in k/k, but still revert the other two.
3. #31, which conditions tostderr output on stderrthreshold
    - Without the addition of #42, this could have resulted in default behavior that silently drops (Info) logs sent to stderr when logtostderr is true. With the revert of #42, this should also be reverted.

Adding these changes back in can be revisited and discussed during code slush, but I would like to back them out in order to get the O_APPEND fix into Kubernetes 1.14.

If we decide to include these changes in upstream Kubernetes, we need to follow the official policy of announcing deprecation of old defaults and waiting the appropriate amount of time before changing them: https://kubernetes.io/docs/reference/using-api/deprecation-policy/. In the future, we need to figure out how to more carefully coordinate changes to defaults in this repo with deprecation policies of other Kubernetes projects.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Recent commits that changed --stderrthreshold default from ERROR to INFO and conditioned --tostderr output on --stderrthreshold have been reverted.
```