### PR TITLE
Set default values only once

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -404,21 +404,36 @@ func init() {
 	go logging.flushDaemon()
 }
 
-// InitFlags is for explicitly initializing the flags
+var initDefaultsOnce sync.Once
+
+// InitFlags is for explicitly initializing the flags.
 func InitFlags(flagset *flag.FlagSet) {
+
+	// Initialize defaults.
+	initDefaultsOnce.Do(func() {
+		logging.logDir = ""
+		logging.logFile = ""
+		logging.logFileMaxSizeMB = 1800
+		logging.toStderr = true
+		logging.alsoToStderr = false
+		logging.skipHeaders = false
+		logging.skipLogHeaders = false
+	})
+
 	if flagset == nil {
 		flagset = flag.CommandLine
 	}
-	flagset.StringVar(&logging.logDir, "log_dir", "", "If non-empty, write log files in this directory")
-	flagset.StringVar(&logging.logFile, "log_file", "", "If non-empty, use this log file")
-	flagset.Uint64Var(&logging.logFileMaxSizeMB, "log_file_max_size", 1800,
+
+	flagset.StringVar(&logging.logDir, "log_dir", logging.logDir, "If non-empty, write log files in this directory")
+	flagset.StringVar(&logging.logFile, "log_file", logging.logFile, "If non-empty, use this log file")
+	flagset.Uint64Var(&logging.logFileMaxSizeMB, "log_file_max_size", logging.logFileMaxSizeMB,
 		"Defines the maximum size a log file can grow to. Unit is megabytes. "+
 			"If the value is 0, the maximum file size is unlimited.")
-	flagset.BoolVar(&logging.toStderr, "logtostderr", true, "log to standard error instead of files")
-	flagset.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
+	flagset.BoolVar(&logging.toStderr, "logtostderr", logging.toStderr, "log to standard error instead of files")
+	flagset.BoolVar(&logging.alsoToStderr, "alsologtostderr", logging.alsoToStderr, "log to standard error as well as files")
 	flagset.Var(&logging.verbosity, "v", "number for the log level verbosity")
-	flagset.BoolVar(&logging.skipHeaders, "skip_headers", false, "If true, avoid header prefixes in the log messages")
-	flagset.BoolVar(&logging.skipLogHeaders, "skip_log_headers", false, "If true, avoid headers when opening log files")
+	flagset.BoolVar(&logging.skipHeaders, "skip_headers", logging.skipHeaders, "If true, avoid header prefixes in the log messages")
+	flagset.BoolVar(&logging.skipLogHeaders, "skip_log_headers", logging.skipLogHeaders, "If true, avoid headers when opening log files")
 	flagset.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
 	flagset.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	flagset.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")

--- a/klog_test.go
+++ b/klog_test.go
@@ -18,6 +18,7 @@ package klog
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	stdLog "log"
@@ -531,5 +532,21 @@ func TestFileSizeCheck(t *testing.T) {
 			t.Fatalf("Error on test case '%v': Was expecting result equals %v, got %v",
 				name, test.expectedResult, actualResult)
 		}
+	}
+}
+
+func TestInitFlags(t *testing.T) {
+	fs1 := flag.NewFlagSet("test1", flag.PanicOnError)
+	InitFlags(fs1)
+	fs1.Set("log_dir", "/test1")
+	fs1.Set("log_file_max_size", "1")
+	fs2 := flag.NewFlagSet("test2", flag.PanicOnError)
+	InitFlags(fs2)
+	if logging.logDir != "/test1" {
+		t.Fatalf("Expected log_dir to be %q, got %q", "/test1", logging.logDir)
+	}
+	fs2.Set("log_file_max_size", "2048")
+	if logging.logFileMaxSizeMB != 2048 {
+		t.Fatal("Expected log_file_max_size to be 2048")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes an issue where `InitFlags` would overwrite values with defaults if called more than once. Props to @liggitt for the sync.Once idea https://github.com/kubernetes/kubernetes/pull/77562#discussion_r284864815

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to 
- https://github.com/kubernetes/kubernetes/pull/77562
- https://github.com/kubernetes/kubernetes/pull/76474
- https://github.com/kubernetes/kubernetes/issues/77416

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```