### PR TITLE
Add Writer type to support io.Writer interface

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -1096,6 +1096,15 @@ func (l *loggingT) setV(pc uintptr) Level {
 	return 0
 }
 
+// Writer implements io.Writer interface as a pass-through for klog.
+type Writer func(args ...interface{})
+
+// Write passes string(p) into Writer's logFunc and always returns len(p)
+func (w Writer) Write(p []byte) (n int, err error) {
+	w(string(p))
+	return len(p), nil
+}
+
 // Verbose is a boolean type that implements Infof (like Printf) etc.
 // See the documentation of V for more information.
 type Verbose bool

--- a/klog_test.go
+++ b/klog_test.go
@@ -583,3 +583,17 @@ func TestInitFlags(t *testing.T) {
 		t.Fatal("Expected log_file_max_size to be 2048")
 	}
 }
+
+// Test that Writer works as advertised.
+func TestWriterInfo(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	w := Writer(Info)
+	fmt.Fprintf(w, "test")
+	if !contains(infoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	}
+	if !contains(infoLog, "test", t) {
+		t.Error("Info failed")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This commit adds Writer type to enable easy
pass through of data to klog functions in an
io.Writer interface.  This is useful especially
when trying to integrate with libraries using
k8s.io/cli-runtime/pkg/genericclioptions.IOStreams.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
There are efforts to make some kubectl code into more portable libraries, such as: https://github.com/kubernetes/kubernetes/pull/80045

Utilizing some of the logic from kubectl in various controllers such as sig-cluster-lifecycle's cluster-api requires implementing an io.Writer interface to capture output from some of these libraries.  Adding a simple type that complies with that interface here enables code reuse for these situations.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Writer type that implements io.Writer interface to easily pass data to logging functions.
```