### PR TITLE
Prevent data race in SetOutput* methods

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -746,6 +746,8 @@ func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
 
 // SetOutput sets the output destination for all severities
 func SetOutput(w io.Writer) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
 	for s := fatalLog; s >= infoLog; s-- {
 		rb := &redirectBuffer{
 			w: w,
@@ -756,6 +758,8 @@ func SetOutput(w io.Writer) {
 
 // SetOutputBySeverity sets the output destination for specific severity
 func SetOutputBySeverity(name string, w io.Writer) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
 	sev, ok := severityByName(name)
 	if !ok {
 		panic(fmt.Sprintf("SetOutputBySeverity(%q): unrecognized severity name", name))

--- a/klog_test.go
+++ b/klog_test.go
@@ -320,6 +320,36 @@ func TestVmoduleOff(t *testing.T) {
 	}
 }
 
+func TestSetOutputDataRace(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	for i := 1; i <= 50; i++ {
+		go func() {
+			logging.flushDaemon()
+		}()
+	}
+	for i := 1; i <= 50; i++ {
+		go func() {
+			SetOutput(ioutil.Discard)
+		}()
+	}
+	for i := 1; i <= 50; i++ {
+		go func() {
+			logging.flushDaemon()
+		}()
+	}
+	for i := 1; i <= 50; i++ {
+		go func() {
+			SetOutputBySeverity("INFO", ioutil.Discard)
+		}()
+	}
+	for i := 1; i <= 50; i++ {
+		go func() {
+			logging.flushDaemon()
+		}()
+	}
+}
+
 // vGlobs are patterns that match/don't match this file at V=2.
 var vGlobs = map[string]bool{
 	// Easy to test the numeric match here.


### PR DESCRIPTION
SetOutput/SetOutputBySeverity should use the mutex intended to protect the `file` flushSyncWriter array.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #81

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```