### PR TITLE
Remove "level" from klogr Info

### DIFF
--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -140,12 +140,11 @@ func pretty(value interface{}) string {
 
 func (l klogger) Info(msg string, kvList ...interface{}) {
 	if l.Enabled() {
-		lvlStr := flatten("level", l.level)
 		msgStr := flatten("msg", msg)
 		trimmed := trimDuplicates(l.values, kvList)
 		fixedStr := flatten(trimmed[0]...)
 		userStr := flatten(trimmed[1]...)
-		klog.InfoDepth(framesToCaller(), l.prefix, " ", lvlStr, " ", msgStr, " ", fixedStr, " ", userStr)
+		klog.InfoDepth(framesToCaller(), l.prefix, " ", msgStr, " ", fixedStr, " ", userStr)
 	}
 }
 

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -28,54 +28,48 @@ func TestInfo(t *testing.T) {
 			klogr:         New().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue"
+			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
 		},
 		"should not print duplicate keys with the same value": {
 			klogr:         New().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue"
+			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
 		},
 		"should only print the last duplicate key when the values are passed to Info": {
 			klogr:         New().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue2"
+			expectedOutput: ` "msg"="test"  "akey"="avalue2"
 `,
 		},
 		"should only print the duplicate key that is passed to Info if one was passed to the logger": {
 			klogr:         New().WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue"
+			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
 		},
 		"should only print the key passed to Info when one is already set on the logger": {
 			klogr:         New().WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue2"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue2"
-`,
-		},
-		"should print different log level if set": {
-			klogr: New().V(4),
-			text:  "test",
-			expectedOutput: ` "level"=4 "msg"="test"  
+			expectedOutput: ` "msg"="test"  "akey"="avalue2"
 `,
 		},
 		"should correctly handle odd-numbers of KVs": {
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: ` "level"=0 "msg"="test"  "akey"="avalue" "akey2"=null
+			expectedOutput: ` "msg"="test"  "akey"="avalue" "akey2"=null
 `,
 		},
 		"should correctly handle odd-numbers of KVs in both log values and Info args": {
 			klogr:         New().WithValues("basekey1", "basevar1", "basekey2"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: ` "level"=0 "msg"="test" "basekey1"="basevar1" "basekey2"=null "akey"="avalue" "akey2"=null
+			expectedOutput: ` "msg"="test" "basekey1"="basevar1" "basekey2"=null "akey"="avalue" "akey2"=null
 `,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR reduces `klogr` verbosity by removing the `"level"=N` key present in every Info line. Usually users set this value before starting a program, or the application decides a sensible default which is printed using CLI help.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed "level" key and value from klogr Info output.
```