### PR TITLE
Starting v2 release following API break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: go
-go_import_path: k8s.io/klog
+go_import_path: k8s.io/klog/v2
 dist: xenial
 go:
-  - 1.9.x
-  - 1.10.x
   - 1.11.x
   - 1.12.x
+  - 1.13.x
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ How to use klog
 - If you want to redirect everything logged using klog somewhere else (say syslog!), you can use `klog.SetOutput()` method and supply a `io.Writer`. (See `examples/set_output/usage_set_output.go`)
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 
+**NOTE**: please use the newer go versions that support semantic import versioning in modules, ideally go 1.11.4 or greater.
+
 ### Coexisting with glog
 This package can be used side by side with glog. [This example](examples/coexist_glog/coexist_glog.go) shows how to initialize and syncronize flags from the global `flag.CommandLine` FlagSet. In addition, the example makes use of stderr as combined output by setting `alsologtostderr` (or `logtostderr`) to `true`.
 

--- a/examples/coexist_glog/coexist_glog.go
+++ b/examples/coexist_glog/coexist_glog.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/golang/glog"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func main() {

--- a/examples/klogr/main.go
+++ b/examples/klogr/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 
-	"k8s.io/klog"
-	"k8s.io/klog/klogr"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 )
 
 type myError struct {

--- a/examples/log_file/usage_log_file.go
+++ b/examples/log_file/usage_log_file.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func main() {

--- a/examples/set_output/usage_set_output.go
+++ b/examples/set_output/usage_set_output.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module k8s.io/klog
+module k8s.io/klog/v2
 
 go 1.12
 

--- a/integration_tests/internal/main.go
+++ b/integration_tests/internal/main.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func main() {

--- a/klog_test.go
+++ b/klog_test.go
@@ -211,7 +211,7 @@ func TestHeaderWithDir(t *testing.T) {
 	pid = 1234
 	Info("test")
 	var line int
-	format := "I0102 15:04:05.067890    1234 klog/klog_test.go:%d] test\n"
+	format := "I0102 15:04:05.067890    1234 v2/klog_test.go:%d] test\n"
 	n, err := fmt.Sscanf(contents(infoLog), format, &line)
 	if n != 1 || err != nil {
 		t.Errorf("log format error: %d elements, error %s:\n%s", n, err, contents(infoLog))

--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 
 	"github.com/go-logr/logr"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // New returns a logr.Logger which is implemented by klog.

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"testing"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/go-logr/logr"
 )


### PR DESCRIPTION
In cd60aa438f9c750641d5feacd2999e58df8af28f, we changed the API leading
to issues like:
```
src/k8s.io/client-go/transport/round_trippers.go:70:11: cannot convert klog.V(9) (type klog.Verbose) to type bool
```

So we should move to v2 of klog

Change-Id: Ibf270e0e6dd326fa91d18140e92139455cbe4de0

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```