### PR TITLE
fix readme error: replace log-file, log-dir to log_file, log_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ How to use klog
 ===============
 - Replace imports for `github.com/golang/glog` with `k8s.io/klog`
 - Use `klog.InitFlags(nil)` explicitly for initializing global flags as we no longer use `init()` method to register the flags
-- You can now use `log-file` instead of `log-dir` for logging to a single file (See `examples/log_file/usage_log_file.go`)
+- You can now use `log_file` instead of `log_dir` for logging to a single file (See `examples/log_file/usage_log_file.go`)
 - If you want to redirect everything logged using klog somewhere else (say syslog!), you can use `klog.SetOutput()` method and supply a `io.Writer`. (See `examples/set_output/usage_set_output.go`)
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 


### PR DESCRIPTION
**What this PR does / why we need it**: log_flag is actually log_file and log_dir, not log-file and log-dir, spelling error in README.