### PR TITLE
Error

### DIFF
--- a/klog_test.go
+++ b/klog_test.go
@@ -390,10 +390,6 @@ func TestVmoduleGlob(t *testing.T) {
 func TestRollover(t *testing.T) {
 	setFlags()
 	var err error
-	defer func(previous func(error)) { logExitFunc = previous }(logExitFunc)
-	logExitFunc = func(e error) {
-		err = e
-	}
 	defer func(previous uint64) { MaxSize = previous }(MaxSize)
 	MaxSize = 512
 	Info("x") // Be sure we have a file.
@@ -439,10 +435,6 @@ func TestOpenAppendOnStart(t *testing.T) {
 
 	setFlags()
 	var err error
-	defer func(previous func(error)) { logExitFunc = previous }(logExitFunc)
-	logExitFunc = func(e error) {
-		err = e
-	}
 
 	f, err := ioutil.TempFile("", "test_klog_OpenAppendOnStart")
 	if err != nil {


### PR DESCRIPTION
Remove os.Exit from klog
    
This PR removes os.Exit from this package, except when log.Fatal(f) is explicitly called. Any errors are returned to the caller who may then decide what to do this with them.
    
Currently no user of klog will check any errors, meaning an application won't be killed when klog thinks it should.

Fixes: #95
    
Signed-off-by: Miek Gieben <miek@miek.nl>
