### PR TITLE
Add LogToOutput, a one-stop shop for writing logs to a io.Writer

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -803,6 +803,16 @@ func SetOutputBySeverity(name string, w io.Writer) {
 	logging.file[sev] = rb
 }
 
+// LogToOutput configures klog to output to the specified writer. It is equivalent to SetOutput()
+// and flag.Set("logtostderr", "false")
+func LogToOutput(w io.Writer) {
+	SetOutput(w)
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+
+	logging.toStderr = false
+}
+
 // output writes the data to the log files and releases the buffer.
 func (l *loggingT) output(s severity, log logr.InfoLogger, buf *buffer, file string, line int, alsoToStderr bool) {
 	l.mu.Lock()

--- a/klog_test.go
+++ b/klog_test.go
@@ -351,6 +351,19 @@ func TestSetOutputDataRace(t *testing.T) {
 	}
 }
 
+func TestLogToOutput(t *testing.T) {
+	defer logging.swap(logging.newBuffers())
+	buf := new(bytes.Buffer)
+	LogToOutput(buf)
+
+	Info("Does LogToOutput work?")
+
+	str := buf.String()
+	if !strings.Contains(str, "Does LogToOutput work?") {
+		t.Fatalf("Expected %s to contain \"Does LogToOutput work?\"", str)
+	}
+}
+
 // vGlobs are patterns that match/don't match this file at V=2.
 var vGlobs = map[string]bool{
 	// Easy to test the numeric match here.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Right now, SetOutput() is mostly useless without also manually setting a flag, as per #87. The way this flag setting interacts with actual flags, flag.Parse() etc is confusing and feels hacky. This change adds a  single method, LogToOutput, which both sets an output and disables logging exclusively to stderr.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #87 (maybe?)

**Special notes for your reviewer**:
I'm not committed to this method name

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add LogToOutput to log to a given io.Writer
```