### PR TITLE
Fix confusing log file example

### DIFF
--- a/examples/log_file/usage_log_file.go
+++ b/examples/log_file/usage_log_file.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"flag"
+
 	"k8s.io/klog/v2"
 )
 
 func main() {
 	klog.InitFlags(nil)
+	// By default klog writes to stderr. Setting logtostderr to false makes klog
+	// write to a log file.
+	flag.Set("logtostderr", "false")
 	flag.Set("log_file", "myfile.log")
 	flag.Parse()
 	klog.Info("nice to meet you")


### PR DESCRIPTION
When people run the log_file example, no log file outputs because
the default value for logtostderr is true and nothing outputs except stderr.

This example confuses people and we should make log file works.