### PR TITLE
add klog.InitFlags(nil) to honour flag setting

### DIFF
--- a/examples/klogr/main.go
+++ b/examples/klogr/main.go
@@ -16,6 +16,7 @@ func (e myError) Error() string {
 }
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Set("v", "3")
 	flag.Parse()
 	log := klogr.New().WithName("MyName").WithValues("user", "you")


### PR DESCRIPTION
**What this PR does / why we need it**:
examples/klogr did not work as  intended as the verbosity flag was ignored, as a result it never logged `nice to meet you`. More importantly, I was confused :-)

**Which issue(s) this PR fixes** :
NONE

**Special notes for your reviewer**:
`klog.InitFlags(nil)` is mandatory as per the docs. It was missing here.

**Release note**:
NONE
