### PR TITLE
Correct comment of Get method

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -132,7 +132,7 @@ func (s *severity) String() string {
 	return strconv.FormatInt(int64(*s), 10)
 }
 
-// Get is part of the flag.Value interface.
+// Get is part of the flag.Getter interface.
 func (s *severity) Get() interface{} {
 	return *s
 }
@@ -221,7 +221,7 @@ func (l *Level) String() string {
 	return strconv.FormatInt(int64(*l), 10)
 }
 
-// Get is part of the flag.Value interface.
+// Get is part of the flag.Getter interface.
 func (l *Level) Get() interface{} {
 	return *l
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit corrects comments of Get method.
Get method is part of flag.Getter inferface, not flag.Value interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No corresponding issue.

**Special notes for your reviewer**:
none