### PR TITLE
Fix test failuer of TestHeaderWithDir in klog_test.go

### DIFF
--- a/klog_test.go
+++ b/klog_test.go
@@ -211,7 +211,7 @@ func TestHeaderWithDir(t *testing.T) {
 	pid = 1234
 	Info("test")
 	var line int
-	format := "I0102 15:04:05.067890    1234 v2/klog_test.go:%d] test\n"
+	format := "I0102 15:04:05.067890    1234 klog/klog_test.go:%d] test\n"
 	n, err := fmt.Sscanf(contents(infoLog), format, &line)
 	if n != 1 || err != nil {
 		t.Errorf("log format error: %d elements, error %s:\n%s", n, err, contents(infoLog))


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This commit fixes test failuer of `TestHeaderWithDir` in `klog_test.go`.

**Which issue(s) this PR fixes**:
**None**

**Special notes for your reviewer**:
**None**

**Release note**:
**None**