### PR TITLE
Fix Set method of traceLocation

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -366,8 +366,11 @@ var errTraceSyntax = errors.New("syntax error: expect file.go:234")
 func (t *traceLocation) Set(value string) error {
 	if value == "" {
 		// Unset.
+		logging.mu.Lock()
+		defer logging.mu.Unlock()
 		t.line = 0
 		t.file = ""
+		return nil
 	}
 	fields := strings.Split(value, ":")
 	if len(fields) != 2 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This commit fixes `Set` method of `traceLocation`.
Till this commit applies, if `Set` method is passed `""` (zero value of strings) as argument `value`, it fails with `errTraceSyntax` at following point
```
fields := strings.Split(value, ":")
if len(fields) != 2 {
	return errTraceSyntax
}
```

This behaivior is not expectation because there is comment of **Unset** not Error/Fail.

**Which issue(s) this PR fixes**:
**None**

**Special notes for your reviewer**:
**None**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
