### PR TITLE
Correct output method to use receiver identifier

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -827,7 +827,7 @@ func (l *loggingT) output(s severity, log logr.InfoLogger, buf *buffer, file str
 			os.Stderr.Write(data)
 		}
 
-		if logging.logFile != "" {
+		if l.logFile != "" {
 			// Since we are using a single log file, all of the items in l.file array
 			// will point to the same file, so just use one of them to write data.
 			if l.file[infoLog] == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This commit corrects `output` method of `loggingT` to use receiver identifier.
Till this commit applies, `output` method of `loggingT` partly uses global variable `logging`.

**Which issue(s) this PR fixes** :
**None**

**Special notes for your reviewer**:
**None**

**Release note**:
