### PR TITLE
Modify output method of loggingT to handle Logger/InfoLogger correctly

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -812,14 +812,17 @@ func (l *loggingT) output(s severity, log logr.InfoLogger, buf *buffer, file str
 		}
 	}
 	data := buf.Bytes()
-	if log != nil {
-		// TODO: set 'severity' and caller information as structured log info
-		// keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
+	// In later version, we should check argument s is either errorLog or infoLog.
+	// However for now, as backward compatibility, all s other than errorLog goes to l.logr.Info().
+	// if l.logr != nil && (s == errorLog || s == infoLog) {
+	if l.logr != nil {
 		if s == errorLog {
-			l.logr.Error(nil, string(data))
+			l.logr.Error(nil, string(data), "severity", severityName[s], "file", file, "line", line)
 		} else {
-			log.Info(string(data))
+			l.logr.Info(string(data), "severity", severityName[s], "file", file, "line", line)
 		}
+	} else if log != nil && s == infoLog {
+		log.Info(string(data), "severity", severityName[s], "file", file, "line", line)
 	} else if l.toStderr {
 		os.Stderr.Write(data)
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit modifies `output` method of `loggingT` to handle `l.logr` or argument `log` correctly, if set.

In this commit `l.logr` is checked first, because if `loggingT.logr`, which is only receiver value of `output` method currently, is set, it should be used unconditionally as comment of `logr` field of `loggingT` says.

Till this commit applies, `output` method is only used with global variable `logging` as receiver and `logging.logr`/`Verbose.logr` as argument `log`.
To maintain backward compatibility, in this commit, `output` method only checks whether argument `s` is `errorLog` or not when `l.logr` is not `nil`.

**Which issue(s) this PR fixes**:
**None**

**Special notes for your reviewer**:
**None**

**Release note**:
**None**