### PR TITLE
klog_file: workaround stdlib.user not supporting Nano Server

### DIFF
--- a/klog_file.go
+++ b/klog_file.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -55,13 +56,31 @@ func init() {
 		host = shortHostname(h)
 	}
 
-	current, err := user.Current()
-	if err == nil {
-		userName = current.Username
-	}
+	// On Windows, the Go 'user' package requires netapi32.dll.
+	// This affects Windows Nano Server:
+	//   https://github.com/golang/go/issues/21867
+	// Fallback to using environment variables.
+	if runtime.GOOS == "windows" {
+		u := os.Getenv("USERNAME")
+		if len(u) == 0 {
+			return
+		}
+		// Sanitize the USERNAME since it may contain filepath separators.
+		u = strings.Replace(u, `\`, "_", -1)
 
-	// Sanitize userName since it may contain filepath separators on Windows.
-	userName = strings.Replace(userName, `\`, "_", -1)
+		// user.Current().Username normally produces something like 'USERDOMAIN\USERNAME'
+		d := os.Getenv("USERDOMAIN")
+		if len(d) != 0 {
+			userName = d + "_" + u
+		} else {
+			userName = u
+		}
+	} else {
+		current, err := user.Current()
+		if err == nil {
+			userName = current.Username
+		}
+	}
 }
 
 // shortHostname returns its argument, truncating at the first period.


### PR DESCRIPTION
**What this PR does / why we need it**:

user.Current() can panic on Windows if the OS is missing
netapi32.dll. This library is stripped from Windows Nano Server.

To workaround this, use environment variables on all versions
on Windows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #122

**Special notes for your reviewer**:
NONE

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix a panic if klog is initialized on Windows Nano Server
```

/kind bug
/priority important-soon
/assign @dims
@lbertvaka
