### PR TITLE
Fix how errors are printed

### DIFF
--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -134,6 +134,11 @@ func flatten(kvList ...interface{}) string {
 }
 
 func pretty(value interface{}) string {
+	if err, ok := value.(error); ok {
+		if _, ok := value.(json.Marshaler); !ok {
+			value = err.Error()
+		}
+	}
 	jb, _ := json.Marshal(value)
 	return string(jb)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes how errors are printed. Previously the regular `error` type would be printed as `{}`.

**Special notes for your reviewer**:
https://play.golang.org/p/iynQRn87vVZ demonstrates the bug

**Release note**:
```release-note
klogr will now print error types using their `Error()` method.
```