### PR TITLE
Fix Windows integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-versions: [1.12.x, 1.13.x, 1.14.x]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/integration_tests/klog_test.go
+++ b/integration_tests/klog_test.go
@@ -2,12 +2,15 @@ package integration_tests_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -181,6 +184,11 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 		},
 	}
 
+	binaryFileExtention := ""
+	if runtime.GOOS == "windows" {
+		binaryFileExtention = ".exe"
+	}
+
 	for tcName, tc := range tests {
 		tc := tc
 		t.Run(tcName, func(t *testing.T) {
@@ -214,13 +222,19 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 				}
 
 				// check files in log_dir
-				for level, file := range logFileName {
-					logfile := filepath.Join(logdir, file) // /some/tmp/dir/main.WARNING
+				for level, levelName := range logFileLevels {
+					binaryName := "main" + binaryFileExtention
+					logfile, err := getLogFilePath(logdir, binaryName, levelName)
 					if tc.expectedLogDir {
+						if err != nil {
+							t.Errorf("Unable to find log file: %v", err)
+						}
 						content := getFileContent(t, logfile)
-						checkForLogs(t, tc.expectedInDir[level], tc.notExpectedInDir[level], content, "logfile["+file+"]")
+						checkForLogs(t, tc.expectedInDir[level], tc.notExpectedInDir[level], content, "logfile["+logfile+"]")
 					} else {
-						assertFileIsAbsent(t, logfile)
+						if err == nil {
+							t.Errorf("Unexpectedly found log file %s", logfile)
+						}
 					}
 				}
 			})
@@ -252,11 +266,11 @@ func klogRun(t *testing.T, flags []string, stderr io.Writer) {
 	}
 }
 
-var logFileName = map[int]string{
-	0: "main.INFO",
-	1: "main.WARNING",
-	2: "main.ERROR",
-	3: "main.FATAL",
+var logFileLevels = map[int]string{
+	0: "INFO",
+	1: "WARNING",
+	2: "ERROR",
+	3: "FATAL",
 }
 
 func getFileContent(t *testing.T, filePath string) string {
@@ -305,4 +319,31 @@ func withTmpDir(t *testing.T, f func(string)) {
 	}()
 
 	f(tmpDir)
+}
+
+// getLogFileFromDir returns the path of either the symbolic link to the logfile, or the the logfile itself. This must
+// be done as the creation of a symlink is not guaranteed on any platform. On Windows, only users with administration
+// privileges can create a symlink.
+func getLogFilePath(dir, binaryName, levelName string) (string, error) {
+	symlink := filepath.Join(dir, binaryName+"."+levelName)
+	if _, err := os.Stat(symlink); err == nil {
+		return symlink, nil
+	}
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("could not read directory %s: %v", dir, err)
+	}
+	var foundFile string
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), binaryName) && strings.Contains(file.Name(), levelName) {
+			if foundFile != "" {
+				return "", fmt.Errorf("found multiple matching files")
+			}
+			foundFile = file.Name()
+		}
+	}
+	if foundFile != "" {
+		return filepath.Join(dir, foundFile), nil
+	}
+	return "", fmt.Errorf("file missing from directory")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes issues with Windows integration tests and enables the
tests to run through github. The problem was that the tests using the
log_dir option expected symlinks to the log files to exist, those
symlinks being (main.INFO, main.WARN, etc). This was a problem for
two reasons:

1) On Windows the symlinks would start with main.exe, not just main
2) The creation of symlinks is not guarenteed on any platform, and on
Windows creating a symlink requires Administrator permissions.

This was fixed by changing the tests to search for either the symlinks
(with a fixed filepath), or the log files themselves.

Future work can be done to deal with the lack of symlinks on Windows,
but this PR's purpose is to get tests in a passing state.

Also includes changes from #137 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #133 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```