### PR TITLE
klog: do not repeat messages on all severity flushSyncWriter

### DIFF
--- a/integration_tests/klog_test.go
+++ b/integration_tests/klog_test.go
@@ -40,6 +40,12 @@ var (
 		2: {stackTraceRE, fatalLogRE, errorLogRE},
 		3: {stackTraceRE, fatalLogRE},
 	}
+	expectedOneOutputInDirREs = map[int]res{
+		0: {infoLogRE},
+		1: {warningLogRE},
+		2: {errorLogRE},
+		3: {fatalLogRE},
+	}
 
 	defaultNotExpectedInDirREs = map[int]res{
 		0: {},
@@ -135,6 +141,18 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			expectedInDir:       defaultExpectedInDirREs,
 			notExpectedInDir:    defaultNotExpectedInDirREs,
 		},
+		"with log dir only and one_output": {
+			// Everything, including the trace on fatal, goes to the log files in the log dir
+
+			logdir: true,
+			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-one_output=true"},
+
+			expectedLogDir: true,
+
+			notExpectedOnStderr: allLogREs,
+			expectedInDir:       expectedOneOutputInDirREs,
+			notExpectedInDir:    defaultNotExpectedInDirREs,
+		},
 		"with log dir and logtostderr": {
 			// Everything, including the trace on fatal, goes to stderr. The -log_dir is
 			// ignored, nothing goes to the log files in the log dir.
@@ -180,6 +198,19 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 
 			expectedOnStderr: allLogREs,
 			expectedInDir:    defaultExpectedInDirREs,
+			notExpectedInDir: defaultNotExpectedInDirREs,
+		},
+		"with log dir, alsologtostderr and one_output": {
+			// Everything, including the trace on fatal, goes to the log file in the
+			// log dir AND to stderr.
+
+			logdir: true,
+			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-one_output=true"},
+
+			expectedLogDir: true,
+
+			expectedOnStderr: allLogREs,
+			expectedInDir:    expectedOneOutputInDirREs,
 			notExpectedInDir: defaultNotExpectedInDirREs,
 		},
 	}

--- a/klog_test.go
+++ b/klog_test.go
@@ -241,6 +241,33 @@ func TestError(t *testing.T) {
 	}
 }
 
+// Test that an Error log does not goes to Warning and Info.
+// Even in the Info log, the source character will be E, so the data should
+// all be identical.
+func TestErrorWithOneOutput(t *testing.T) {
+	setFlags()
+	logging.oneOutput = true
+	buf := logging.newBuffers()
+	defer func() {
+		logging.swap(buf)
+		logging.oneOutput = false
+	}()
+	Error("test")
+	if !contains(errorLog, "E", t) {
+		t.Errorf("Error has wrong character: %q", contents(errorLog))
+	}
+	if !contains(errorLog, "test", t) {
+		t.Error("Error failed")
+	}
+	str := contents(errorLog)
+	if contains(warningLog, str, t) {
+		t.Error("Warning failed")
+	}
+	if contains(infoLog, str, t) {
+		t.Error("Info failed")
+	}
+}
+
 // Test that a Warning log goes to Info.
 // Even in the Info log, the source character will be W, so the data should
 // all be identical.
@@ -256,6 +283,30 @@ func TestWarning(t *testing.T) {
 	}
 	str := contents(warningLog)
 	if !contains(infoLog, str, t) {
+		t.Error("Info failed")
+	}
+}
+
+// Test that a Warning log does not goes to Info.
+// Even in the Info log, the source character will be W, so the data should
+// all be identical.
+func TestWarningWithOneOutput(t *testing.T) {
+	setFlags()
+	logging.oneOutput = true
+	buf := logging.newBuffers()
+	defer func() {
+		logging.swap(buf)
+		logging.oneOutput = false
+	}()
+	Warning("test")
+	if !contains(warningLog, "W", t) {
+		t.Errorf("Warning has wrong character: %q", contents(warningLog))
+	}
+	if !contains(warningLog, "test", t) {
+		t.Error("Warning failed")
+	}
+	str := contents(warningLog)
+	if contains(infoLog, str, t) {
 		t.Error("Info failed")
 	}
 }


### PR DESCRIPTION
If a log message for a particular severity is created, it should be
enough to log such message in its flushSyncWriter. Having a fallthrough
on each switch statement will make the messages to be duplicated on each
flushSyncWriters that follows the selected case.

Signed-off-by: André Martins <aanm90@gmail.com>

**Release note**:
```release-note
klog: do not repeat messages for all severity writers
```