### PR TITLE
logName(): lazily lookup userName instead of on init()

### DIFF
--- a/klog_file.go
+++ b/klog_file.go
@@ -44,43 +44,49 @@ func createLogDirs() {
 }
 
 var (
-	pid      = os.Getpid()
-	program  = filepath.Base(os.Args[0])
-	host     = "unknownhost"
-	userName = "unknownuser"
+	pid          = os.Getpid()
+	program      = filepath.Base(os.Args[0])
+	host         = "unknownhost"
+	userName     = "unknownuser"
+	userNameOnce sync.Once
 )
 
 func init() {
-	h, err := os.Hostname()
-	if err == nil {
+	if h, err := os.Hostname(); err == nil {
 		host = shortHostname(h)
 	}
+}
 
-	// On Windows, the Go 'user' package requires netapi32.dll.
-	// This affects Windows Nano Server:
-	//   https://github.com/golang/go/issues/21867
-	// Fallback to using environment variables.
-	if runtime.GOOS == "windows" {
-		u := os.Getenv("USERNAME")
-		if len(u) == 0 {
-			return
-		}
-		// Sanitize the USERNAME since it may contain filepath separators.
-		u = strings.Replace(u, `\`, "_", -1)
+func getUserName() string {
+	userNameOnce.Do(func() {
+		// On Windows, the Go 'user' package requires netapi32.dll.
+		// This affects Windows Nano Server:
+		//   https://github.com/golang/go/issues/21867
+		// Fallback to using environment variables.
+		if runtime.GOOS == "windows" {
+			u := os.Getenv("USERNAME")
+			if len(u) == 0 {
+				return
+			}
+			// Sanitize the USERNAME since it may contain filepath separators.
+			u = strings.Replace(u, `\`, "_", -1)
 
-		// user.Current().Username normally produces something like 'USERDOMAIN\USERNAME'
-		d := os.Getenv("USERDOMAIN")
-		if len(d) != 0 {
-			userName = d + "_" + u
+			// user.Current().Username normally produces something like 'USERDOMAIN\USERNAME'
+			d := os.Getenv("USERDOMAIN")
+			if len(d) != 0 {
+				userName = d + "_" + u
+			} else {
+				userName = u
+			}
 		} else {
-			userName = u
+			current, err := user.Current()
+			if err == nil {
+				userName = current.Username
+			}
 		}
-	} else {
-		current, err := user.Current()
-		if err == nil {
-			userName = current.Username
-		}
-	}
+	})
+
+	return userName
 }
 
 // shortHostname returns its argument, truncating at the first period.
@@ -98,7 +104,7 @@ func logName(tag string, t time.Time) (name, link string) {
 	name = fmt.Sprintf("%s.%s.%s.log.%s.%04d%02d%02d-%02d%02d%02d.%d",
 		program,
 		host,
-		userName,
+		getUserName(),
 		tag,
 		t.Year(),
 		t.Month(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Commit c46b9e13e600dbe96a19e86a8eb5dbf9ebe00ffa (https://github.com/kubernetes/klog/pull/123, and backported to v1 through https://github.com/kubernetes/klog/pull/124) implemented a workaround for situations on Windows where `user.Current()` was not available.

On Linux/Unix ennvironments, `user.Current()` may be calling (among others) `getgrnam_r` (https://linux.die.net/man/3/getgrgid_r), which:

> Returns a pointer to a structure containing the broken-out fields of
> the record in the group database (e.g., the local group file /etc/group,
> NIS, and LDAP) that matches the group name name.

This means that the `init()` function might be making network connections,
which is not desirable.

This patch changes the lookup to be performed lazily. A `sync.Once` was
added so that lookup is only performed once (to keep the behavior that
was previously provided by using `init()`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Relates to https://github.com/kubernetes/klog/pull/123
Relates to https://github.com/docker/cli/issues/2420

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

If accepted, I would like this to see this backported to the v1 branch (and possibly included in a `v1.0.1` or `v1.0.2` release)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Perform userName lookup lazily, instead of on init()
```