### PR TITLE
Add some useful constants

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -567,6 +567,9 @@ func (l *loggingT) putBuffer(b *buffer) {
 
 var timeNow = time.Now // Stubbed out for testing.
 
+// DefaultPrefixLength is the length of all the things we add up in the header below
+const DefaultPrefixLength = 53
+
 /*
 header formats a log header as defined by the C++ implementation.
 It returns a buffer containing the formatted header and the user's file and line number.
@@ -815,6 +818,11 @@ func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
 	return rb.w.Write(bytes)
 }
 
+// LoggerCallDepth is the depth of the stack where we would find the information about
+// the file name/line number of the code that called klogv2. This can be used from
+// within the methods of logr.Logger passed to SetLogger below.
+const LoggerCallDepth = 5
+
 // SetLogger will set the backing logr implementation for klog.
 // If set, all log lines will be suppressed from the regular Output, and
 // redirected to the logr implementation.
@@ -826,6 +834,11 @@ func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
 func SetLogger(logr logr.Logger) {
 	logging.logr = logr
 }
+
+// OutputCallDepth is the depth of the stack where we would find the information about
+// the file name/line number of the code that called klogv2. This can be used from
+// within the Write method of io.Writer passed to SetOutput below.
+const OutputCallDepth = 6
 
 // SetOutput sets the output destination for all severities
 func SetOutput(w io.Writer) {


### PR DESCRIPTION
Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Constants useful for the examples that i will be adding shortly in https://github.com/kubernetes/klog/pull/142

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added some constants we could use from logr.Logger and io.Writer methods
```