### PR TITLE
Fix missing fields in verbose InfoS

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -1320,7 +1320,7 @@ func (v Verbose) Infof(format string, args ...interface{}) {
 // See the documentation of V for usage.
 func (v Verbose) InfoS(msg string, keysAndValues ...interface{}) {
 	if v.enabled {
-		logging.infoS(v.logr, msg, keysAndValues)
+		logging.infoS(v.logr, msg, keysAndValues...)
 	}
 }
 


### PR DESCRIPTION
Fixes #165

The recent update to v2.1.0 highlighted the omission of `...` in Verbose.InfoS when calling loggingT.infoS.

This complies because the final parameter for loggingT.infoS, accepts `...interface{}` and that interface just thinks all the key value pairs forms a single array. This produces output like `[key value]=(missing)` instead of `key="value"`