### PR TITLE
Hooks support

### DIFF
--- a/examples/hook/hook.go
+++ b/examples/hook/hook.go
@@ -1,0 +1,22 @@
+package hook
+
+import (
+    "fmt"
+)
+
+type Hook struct {}
+
+func NewHook() (*Hook, error) {
+    return &Hook{
+
+    }, nil
+}
+
+func (hook *Hook) SeverityLevel() string {
+    return "INFO"
+}
+
+func (hook *Hook) Fire(s string, args ...interface{}) error {
+    fmt.Printf("firing hook, severity: %v, message: %v\n", s, args)
+    return nil
+}

--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,92 @@
+// Go support for leveled logs, analogous to https://code.google.com/p/google-glog/
+//
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package klog
+
+import (
+	"fmt"
+)
+
+// Hook to be fired when logging to a severity
+type Hook interface {
+	// SeverityLevel returns "INFO", "WARNING", "ERROR" or "FATAL"
+	// Hook will be fired in all the cases when severity is greater than
+	// or equal to the severity level
+	SeverityLevel() string
+
+	// Fire implements the actual hook task that needs to be triggered
+	Fire(s string, args ...interface{}) error
+}
+
+func GetSeverityNames() []string {
+	var severityNames []string
+	for _, s := range severityName {
+		severityNames = append(severityNames, s)
+	}
+
+	return severityNames
+}
+
+func IsSeverityLevelSupported(severityLevel string) error {
+	severityNames := GetSeverityNames()
+	for _, s := range severityNames {
+		if s == severityLevel {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"not supported severity level: %s, supported severity levels are: %v",
+		severityLevel,
+		severityNames,
+	)
+}
+
+type Hooks map[string][]Hook
+
+func (hooks Hooks) Add(hook Hook) error {
+	severityLevel := hook.SeverityLevel()
+	err := IsSeverityLevelSupported(severityLevel)
+	if err != nil {
+		return err
+	}
+	hooks[severityLevel] = append(hooks[severityLevel], hook)
+
+	return nil
+}
+
+func (hooks Hooks) Fire(s severity, args ...interface{}) error {
+	for severityLevel, severityHooks := range hooks {
+		level, ok := severityByName(severityLevel)
+		if !ok {
+			return fmt.Errorf(
+				"error getting severity name for: %s", severityLevel,
+			)
+		}
+
+		if s < level {
+			continue
+		}
+
+		for _, hook := range severityHooks {
+			if err := hook.Fire(severityName[s], args); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/hooks.go
+++ b/hooks.go
@@ -20,6 +20,13 @@ import (
 	"fmt"
 )
 
+var (
+	InfoSeverityLevel    = severityName[infoLog]
+	WarningSeverityLevel = severityName[warningLog]
+	ErrorSeverityLevel   = severityName[errorLog]
+	FatalSeverityLevel   = severityName[fatalLog]
+)
+
 // Hook to be fired when logging to a severity
 type Hook interface {
 	// SeverityLevel returns "INFO", "WARNING", "ERROR" or "FATAL"

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -1,0 +1,115 @@
+package klog
+
+import (
+	"strconv"
+	"testing"
+)
+
+type testHook struct {
+	severityLevel string
+	fired         map[string]int
+}
+
+func newTestHook(severityLevel string) *testHook {
+	return &testHook{
+		severityLevel: severityLevel,
+		fired:         make(map[string]int),
+	}
+}
+
+func (t *testHook) SeverityLevel() string {
+	return t.severityLevel
+}
+
+func (t *testHook) Fire(s string, args ...interface{}) error {
+	if _, ok := t.fired[s]; !ok {
+		t.fired[s] = 1
+		return nil
+	}
+	t.fired[s]++
+
+	return nil
+}
+
+// validate takes the execpted value, and returns if the result
+// was favourable and the got value as a string
+func (t *testHook) validateFiring(
+	expectedKey string, expectedValue int) (bool, string) {
+
+	val, ok := t.fired[expectedKey]
+	if !ok {
+		return false, ""
+	}
+
+	if val != expectedValue {
+		return false, strconv.Itoa(val)
+	}
+
+	return true, strconv.Itoa(val)
+}
+
+func TestCanFireHooks(t *testing.T) {
+	hook := newTestHook(InfoSeverityLevel)
+
+	AddHook(hook)
+
+	Info("fire info 1")
+	Info("fire info 2")
+	expected, got := hook.validateFiring(InfoSeverityLevel, 2)
+	if !expected {
+		t.Errorf("unexpected firing result: got:\n\t%s \nwant:\t%d", got, 2)
+	}
+
+	Error("fire error 3")
+	expected, got = hook.validateFiring(ErrorSeverityLevel, 1)
+	if !expected {
+		t.Errorf("unexpected firing result: got:\n\t%s \nwant:\t%d", got, 1)
+	}
+
+	_, ok := hook.fired[FatalSeverityLevel]
+	if ok {
+		t.Errorf("hook firing %s was not expected", FatalSeverityLevel)
+	}
+}
+
+func TestAddingUnsupportedHook(t *testing.T) {
+	severityLevel := "PANIC"
+
+	hook := newTestHook(severityLevel)
+
+	hooks := Hooks{}
+	err := hooks.Add(hook)
+	if err == nil {
+		t.Errorf(
+			"error was expected as severity: %s is not supported",
+			severityLevel,
+		)
+	}
+}
+
+func TestCanFireMultipleHooks(t *testing.T) {
+	hook1 := newTestHook(InfoSeverityLevel)
+	hook2 := newTestHook(ErrorSeverityLevel)
+
+	AddHook(hook1)
+	AddHook(hook2)
+
+	Info("fire info 1")
+	Error("fire error 1")
+	expected, got := hook1.validateFiring(InfoSeverityLevel, 1)
+	if !expected {
+		t.Errorf("unexpected firing result: got:\n\t%s \nwant:\t%d", got, 1)
+	}
+	expected, got = hook1.validateFiring(ErrorSeverityLevel, 1)
+	if !expected {
+		t.Errorf("unexpected firing result: got:\n\t%s \nwant:\t%d", got, 1)
+	}
+	expected, got = hook2.validateFiring(ErrorSeverityLevel, 1)
+	if !expected {
+		t.Errorf("unexpected firing result: got:\n\t%s \nwant:\t%d", got, 1)
+	}
+	_, ok := hook2.fired[InfoSeverityLevel]
+	if ok {
+		t.Errorf("hook2 firing %s was not expected", InfoSeverityLevel)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds hooks support in klog

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/klog/issues/167

**Special notes for your reviewer**:
`severity` had to be made Public for adding hook support.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Testing this PR**:
This PR was tested using the below script
```go
package main

import (
    "fmt"
    "k8s.io/klog/v2"
)

type Hook struct {}

func NewHook() (*Hook, error) {
    return &Hook{

    }, nil
}

func (hook *Hook) SeverityLevel() string {
    return "INFO"
}

func (hook *Hook) Fire(s string, args ...interface{}) error {
    fmt.Printf("firing hook, severity: %v, message: %v\n", s, args)
    return nil
}

func main() {
    klog.InitFlags(nil)

    hook, err := NewHook()
    if err != nil {
        klog.Fatal("error making hook")
    }

    klog.AddHook(hook)

    klog.Error("hello hooks")
}
```

**Output:**
```bash
E0622 13:03:14.891839    9589 main.go:35] hello hooks
firing hook, severity: ERROR, message: [[]]
```

**Hook for prometheus:** https://github.com/practo/promlog