### PR TITLE
Deprecate typo-ed Structured logging method (Error->ErrorS)

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -1324,9 +1324,16 @@ func (v Verbose) InfoS(msg string, keysAndValues ...interface{}) {
 	}
 }
 
-// Error is equivalent to the global Error function, guarded by the value of v.
-// See the documentation of V for usage.
+// Deprecated: Use ErrorS instead.
 func (v Verbose) Error(err error, msg string, args ...interface{}) {
+	if v.enabled {
+		logging.errorS(err, v.logr, msg, args...)
+	}
+}
+
+// ErrorS is equivalent to the global Error function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) ErrorS(err error, msg string, args ...interface{}) {
 	if v.enabled {
 		logging.errorS(err, v.logr, msg, args...)
 	}

--- a/klog.go
+++ b/klog.go
@@ -1333,7 +1333,7 @@ func (v Verbose) Error(err error, msg string, args ...interface{}) {
 
 // ErrorS is equivalent to the global Error function, guarded by the value of v.
 // See the documentation of V for usage.
-func (v Verbose) ErrorS(err error, msg string, args ...interface{}) {
+func (v Verbose) ErrorS(err error, msg string, keysAndValues ...interface{}) {
 	if v.enabled {
 		logging.errorS(err, v.logr, msg, args...)
 	}

--- a/klog.go
+++ b/klog.go
@@ -1335,7 +1335,7 @@ func (v Verbose) Error(err error, msg string, args ...interface{}) {
 // See the documentation of V for usage.
 func (v Verbose) ErrorS(err error, msg string, keysAndValues ...interface{}) {
 	if v.enabled {
-		logging.errorS(err, v.logr, msg, args...)
+		logging.errorS(err, v.logr, msg, keysAndValues...)
 	}
 }
 


### PR DESCRIPTION
Structured logging methods should have a `S` suffix.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate Error method and use ErrorS instead.
```