### PR TITLE
Set GO111MODULE=off for go get golang.org/x/exp/cmd/apidiff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Add GOBIN to PATH
         run: echo "::add-path::$(go env GOPATH)/bin"
       - name: Install dependencies
-        run: go get golang.org/x/exp/cmd/apidiff
+        run: GO111MODULE=off go get golang.org/x/exp/cmd/apidiff
       - name: Checkout old code
         uses: actions/checkout@v2
         with:

--- a/hack/verify-apidiff.sh
+++ b/hack/verify-apidiff.sh
@@ -65,7 +65,7 @@ fi
 if ! which apidiff > /dev/null; then
   echo "Installing golang.org/x/exp/cmd/apidiff..."
   pushd "${TMPDIR:-/tmp}" > /dev/null
-    go get golang.org/x/exp/cmd/apidiff
+    GO111MODULE=off go get golang.org/x/exp/cmd/apidiff
   popd > /dev/null
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid adding a dependency on golang.org/x/exp/cmd/apidiff to `go.mod` when running `go get golang.org/x/exp/cmd/apidiff`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
none

**Special notes for your reviewer**:
none

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```