### PR TITLE
Lint coexist klog1 and klog2 example

### DIFF
--- a/examples/coexist_klog_v1_and_v2/coexist_klog_v1_and_v2.go
+++ b/examples/coexist_klog_v1_and_v2/coexist_klog_v1_and_v2.go
@@ -9,7 +9,8 @@ import (
 
 // OutputCallDepth is the stack depth where we can find the origin of this call
 const OutputCallDepth = 6
-// log prefix that we have to strip out
+
+// DefaultPrefixLength is the length of the log prefix that we have to strip out
 const DefaultPrefixLength = 53
 
 // klogWriter is used in SetOutputBySeverity call below to redirect
@@ -60,8 +61,9 @@ func main() {
 	klogv1.InitFlags(&klogv1Flags)
 	klogv1Flags.Set("logtostderr", "false")     // By default klog v1 logs to stderr, switch that off
 	klogv1Flags.Set("stderrthreshold", "FATAL") // stderrthreshold defaults to ERROR, use this if you
-															 // don't want anything in your stderr
-	klogv1.SetOutputBySeverity("INFO", klogWriter{})  // tell klog v1 to use the writer
+	// don't want anything in your stderr
+
+	klogv1.SetOutputBySeverity("INFO", klogWriter{}) // tell klog v1 to use the writer
 	// END : hack to redirect klogv1 calls to klog v2
 
 	// Now you can mix klogv1 and v2 in the same code base


### PR DESCRIPTION
**What this PR does / why we need it**:
* Resolve linting errors found via https://goreportcard.com/report/github.com/kubernetes/klog

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```