### PR TITLE
add log file rotation

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -408,6 +408,8 @@ func init() {
 	logging.logDir = ""
 	logging.logFile = ""
 	logging.logFileMaxSizeMB = 1800
+	logging.logFileMaxBackups = 0
+	logging.logFileIndex = 1
 	logging.toStderr = true
 	logging.alsoToStderr = false
 	logging.skipHeaders = false
@@ -424,10 +426,12 @@ func InitFlags(flagset *flag.FlagSet) {
 	}
 
 	flagset.StringVar(&logging.logDir, "log_dir", logging.logDir, "If non-empty, write log files in this directory")
-	flagset.StringVar(&logging.logFile, "log_file", logging.logFile, "If non-empty, use this log file")
+	flagset.StringVar(&logging.logFile, "log_file", logging.logFile, "If non-empty, use this log file (mutually exclusive with the log-dir option)")
 	flagset.Uint64Var(&logging.logFileMaxSizeMB, "log_file_max_size", logging.logFileMaxSizeMB,
 		"Defines the maximum size a log file can grow to. Unit is megabytes. "+
 			"If the value is 0, the maximum file size is unlimited.")
+	flagset.IntVar(&logging.logFileMaxBackups, "log_file_max_backups", logging.logFileMaxBackups,
+		"Defines the max number rotation log files kept. If this value is 0, no backup rotation file will be kept")
 	flagset.BoolVar(&logging.toStderr, "logtostderr", logging.toStderr, "log to standard error instead of files")
 	flagset.BoolVar(&logging.alsoToStderr, "alsologtostderr", logging.alsoToStderr, "log to standard error as well as files")
 	flagset.Var(&logging.verbosity, "v", "number for the log level verbosity")
@@ -495,6 +499,12 @@ type loggingT struct {
 	// When logFile is specified, this limiter makes sure the logFile won't exceeds a certain size. When exceeds, the
 	// logFile will be cleaned up. If this value is 0, no size limitation will be applied to logFile.
 	logFileMaxSizeMB uint64
+
+	// Keep the logFileMaxBackups rotation log files. If this value is 0, no backup rotation file will be kept.
+	logFileMaxBackups int
+
+	// Record every logFile a increase index, to avoid log loss when log rotate twice in one second
+	logFileIndex uint64
 
 	// If true, do not add the prefix headers, useful when used with SetOutput
 	skipHeaders bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
When I was developing an extension apiserver, I found it impossible to set how much files the log_file to keep. When the log file reaches the max size, it just cleans the file directly.   
And if I set the log with a log_dir, I have to configure an additional cleanup script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add support for log_file rotation
```