### PR TITLE
README.md: Mention klog/v2 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ Historical context is available here:
 
 How to use klog
 ===============
-- Replace imports for `github.com/golang/glog` with `k8s.io/klog`
+- Replace imports for `"github.com/golang/glog"` with `"k8s.io/klog/v2"`
 - Use `klog.InitFlags(nil)` explicitly for initializing global flags as we no longer use `init()` method to register the flags
 - You can now use `log_file` instead of `log_dir` for logging to a single file (See `examples/log_file/usage_log_file.go`)
 - If you want to redirect everything logged using klog somewhere else (say syslog!), you can use `klog.SetOutput()` method and supply a `io.Writer`. (See `examples/set_output/usage_set_output.go`)
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 
 **NOTE**: please use the newer go versions that support semantic import versioning in modules, ideally go 1.11.4 or greater.
+
+### Coexisting with klog/v2
+
+See [this example](examples/coexist_klog_v1_and_v2/) to see how to coexist with both klog/v1 and klog/v2.
 
 ### Coexisting with glog
 This package can be used side by side with glog. [This example](examples/coexist_glog/coexist_glog.go) shows how to initialize and synchronize flags from the global `flag.CommandLine` FlagSet. In addition, the example makes use of stderr as combined output by setting `alsologtostderr` (or `logtostderr`) to `true`.


### PR DESCRIPTION


**What this PR does / why we need it**:
To avoid new users using v1 of klog, we should explicitly mention the klog/v2 import path.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/klog/issues/181

**Special notes for your reviewer**:
Just docs.

**Release note**:
N/A

cc @dims let me know I can drop the example mention from the README, but was useful to me just not very discoverable. Thanks!