### PR TITLE
Fix issue where no keys and values are sent to logr when using structured logging with json

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -759,7 +759,7 @@ func (l *loggingT) printWithFileLine(s severity, logr logr.Logger, file string, 
 // if loggr is specified, will call loggr.Error, otherwise output with logging module.
 func (l *loggingT) errorS(err error, loggr logr.Logger, msg string, keysAndValues ...interface{}) {
 	if loggr != nil {
-		loggr.Error(err, msg, keysAndValues)
+		loggr.Error(err, msg, keysAndValues...)
 		return
 	}
 	l.printS(err, msg, keysAndValues...)

--- a/klog.go
+++ b/klog.go
@@ -768,7 +768,7 @@ func (l *loggingT) errorS(err error, loggr logr.Logger, msg string, keysAndValue
 // if loggr is specified, will call loggr.Info, otherwise output with logging module.
 func (l *loggingT) infoS(loggr logr.Logger, msg string, keysAndValues ...interface{}) {
 	if loggr != nil {
-		loggr.Info(msg, keysAndValues)
+		loggr.Info(msg, keysAndValues...)
 		return
 	}
 	l.printS(nil, msg, keysAndValues...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix issue where no keys and values are sent to logr when using structured logging with json.

**Which issue(s) this PR fixes**:
Fixes #185 

**Release note**:
```release-note
Fixed issue where no keys and values where passed on to logr when using structured logging with json
```