### PR TITLE
klogr output format

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -772,7 +772,7 @@ func (l *loggingT) printWithFileLine(s severity, logr logr.Logger, filter LogFil
 }
 
 // if loggr is specified, will call loggr.Error, otherwise output with logging module.
-func (l *loggingT) errorS(err error, loggr logr.Logger, filter LogFilter, msg string, keysAndValues ...interface{}) {
+func (l *loggingT) errorS(err error, loggr logr.Logger, filter LogFilter, depth int, msg string, keysAndValues ...interface{}) {
 	if filter != nil {
 		msg, keysAndValues = filter.FilterS(msg, keysAndValues)
 	}
@@ -780,11 +780,11 @@ func (l *loggingT) errorS(err error, loggr logr.Logger, filter LogFilter, msg st
 		loggr.Error(err, msg, keysAndValues...)
 		return
 	}
-	l.printS(err, msg, keysAndValues...)
+	l.printS(err, depth+1, msg, keysAndValues...)
 }
 
 // if loggr is specified, will call loggr.Info, otherwise output with logging module.
-func (l *loggingT) infoS(loggr logr.Logger, filter LogFilter, msg string, keysAndValues ...interface{}) {
+func (l *loggingT) infoS(loggr logr.Logger, filter LogFilter, depth int, msg string, keysAndValues ...interface{}) {
 	if filter != nil {
 		msg, keysAndValues = filter.FilterS(msg, keysAndValues)
 	}
@@ -792,12 +792,12 @@ func (l *loggingT) infoS(loggr logr.Logger, filter LogFilter, msg string, keysAn
 		loggr.Info(msg, keysAndValues...)
 		return
 	}
-	l.printS(nil, msg, keysAndValues...)
+	l.printS(nil, depth+1, msg, keysAndValues...)
 }
 
 // printS is called from infoS and errorS if loggr is not specified.
 // if err arguments is specified, will output to errorLog severity
-func (l *loggingT) printS(err error, msg string, keysAndValues ...interface{}) {
+func (l *loggingT) printS(err error, depth int, msg string, keysAndValues ...interface{}) {
 	b := &bytes.Buffer{}
 	b.WriteString(fmt.Sprintf("%q", msg))
 	if err != nil {
@@ -811,7 +811,7 @@ func (l *loggingT) printS(err error, msg string, keysAndValues ...interface{}) {
 	} else {
 		s = errorLog
 	}
-	l.printDepth(s, logging.logr, nil, 2, b)
+	l.printDepth(s, logging.logr, nil, depth+1, b)
 }
 
 const missingValue = "(MISSING)"
@@ -1359,14 +1359,20 @@ func (v Verbose) Infof(format string, args ...interface{}) {
 // See the documentation of V for usage.
 func (v Verbose) InfoS(msg string, keysAndValues ...interface{}) {
 	if v.enabled {
-		logging.infoS(v.logr, v.filter, msg, keysAndValues...)
+		logging.infoS(v.logr, v.filter, 0, msg, keysAndValues...)
 	}
+}
+
+// InfoSDepth acts as InfoS but uses depth to determine which call frame to log.
+// InfoSDepth(0, "msg") is the same as InfoS("msg").
+func InfoSDepth(depth int, msg string, keysAndValues ...interface{}) {
+	logging.infoS(logging.logr, logging.filter, depth, msg, keysAndValues...)
 }
 
 // Deprecated: Use ErrorS instead.
 func (v Verbose) Error(err error, msg string, args ...interface{}) {
 	if v.enabled {
-		logging.errorS(err, v.logr, v.filter, msg, args...)
+		logging.errorS(err, v.logr, v.filter, 0, msg, args...)
 	}
 }
 
@@ -1374,7 +1380,7 @@ func (v Verbose) Error(err error, msg string, args ...interface{}) {
 // See the documentation of V for usage.
 func (v Verbose) ErrorS(err error, msg string, keysAndValues ...interface{}) {
 	if v.enabled {
-		logging.errorS(err, v.logr, v.filter, msg, keysAndValues...)
+		logging.errorS(err, v.logr, v.filter, 0, msg, keysAndValues...)
 	}
 }
 
@@ -1411,7 +1417,7 @@ func Infof(format string, args ...interface{}) {
 // output:
 // >> I1025 00:15:15.525108       1 controller_utils.go:116] "Pod status updated" pod="kubedns" status="ready"
 func InfoS(msg string, keysAndValues ...interface{}) {
-	logging.infoS(logging.logr, logging.filter, msg, keysAndValues...)
+	logging.infoS(logging.logr, logging.filter, 0, msg, keysAndValues...)
 }
 
 // Warning logs to the WARNING and INFO logs.
@@ -1472,7 +1478,13 @@ func Errorf(format string, args ...interface{}) {
 // output:
 // >> E1025 00:15:15.525108       1 controller_utils.go:114] "Failed to update pod status" err="timeout"
 func ErrorS(err error, msg string, keysAndValues ...interface{}) {
-	logging.errorS(err, logging.logr, logging.filter, msg, keysAndValues...)
+	logging.errorS(err, logging.logr, logging.filter, 0, msg, keysAndValues...)
+}
+
+// ErrorSDepth acts as ErrorS but uses depth to determine which call frame to log.
+// ErrorSDepth(0, "msg") is the same as ErrorS("msg").
+func ErrorSDepth(depth int, err error, msg string, keysAndValues ...interface{}) {
+	logging.errorS(err, logging.logr, logging.filter, depth, msg, keysAndValues...)
 }
 
 // Fatal logs to the FATAL, ERROR, WARNING, and INFO logs,

--- a/klog_wrappers_test.go
+++ b/klog_wrappers_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package klog
+
+// These helper functions must be in a separate source file because the
+// tests in klog_test.go compare the logged source code file name against
+// "klog_test.go". "klog_wrappers_test.go" must *not* be logged.
+
+func myInfoS(msg string, keyAndValues ...interface{}) {
+	InfoSDepth(1, msg, keyAndValues...)
+}
+
+func myErrorS(err error, msg string, keyAndValues ...interface{}) {
+	ErrorSDepth(1, err, msg, keyAndValues...)
+}

--- a/klogr/README.md
+++ b/klogr/README.md
@@ -5,4 +5,15 @@ in terms of Kubernetes' [klog](https://github.com/kubernetes/klog).  This
 provides a relatively minimalist API to logging in Go, backed by a well-proven
 implementation.
 
+Because klogr was implemented before klog itself added supported for
+structured logging, the default in klogr is to serialize key/value
+pairs with JSON and log the result as text messages via klog. This
+does not work well when klog itself forwards output to a structured
+logger.
+
+Therefore the recommended approach is to let klogr pass all log
+messages through to klog and deal with structured logging there. Just
+beware that the output of klog without a structured logger is meant to
+be human-readable, in contrast to the JSON-based traditional format.
+
 This is a BETA grade implementation.

--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -31,25 +31,28 @@ const (
 	FormatKlog Format = "Klog"
 )
 
-// WithFormat selects the output format. Default is FormatSerialize as in
-// previous releases of klog.
+// WithFormat selects the output format.
 func WithFormat(format Format) Option {
 	return func(l *klogger) {
 		l.format = format
 	}
 }
 
-// New returns a logr.Logger which is implemented by klog.
-//
-// Whether it serializes key/value pairs itself (the traditional
-// behavior, enabled by default) or lets klog do that is configurable
-// via the Format option.
-func New(options ...Option) logr.Logger {
+// New returns a logr.Logger which serializes output itself
+// and writes it via klog.
+func New() logr.Logger {
+	return NewWithOptions(WithFormat(FormatSerialize))
+}
+
+// NewWithOptions returns a logr.Logger which serializes as determined
+// by the WithFormat option and writes via klog. The default is
+// FormatKlog.
+func NewWithOptions(options ...Option) logr.Logger {
 	l := klogger{
 		level:  0,
 		prefix: "",
 		values: nil,
-		format: FormatSerialize,
+		format: FormatKlog,
 	}
 	for _, option := range options {
 		option(&l)

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -13,76 +13,93 @@ import (
 	"github.com/go-logr/logr"
 )
 
-func TestOutput(t *testing.T) {
-	klog.InitFlags(nil)
-	flag.CommandLine.Set("v", "10")
-	flag.CommandLine.Set("skip_headers", "true")
-	flag.CommandLine.Set("logtostderr", "false")
-	flag.CommandLine.Set("alsologtostderr", "false")
-	flag.CommandLine.Set("stderrthreshold", "10")
-	flag.Parse()
+const (
+	formatDefault = "Default"
+)
 
+func testOutput(t *testing.T, format string) {
+	var options []Option
+	if format != formatDefault {
+		options = append(options, WithFormat(Format(format)))
+	}
 	tests := map[string]struct {
-		klogr          logr.Logger
-		text           string
-		keysAndValues  []interface{}
-		err            error
-		expectedOutput string
+		klogr              logr.Logger
+		text               string
+		keysAndValues      []interface{}
+		err                error
+		expectedOutput     string
+		expectedKlogOutput string
 	}{
 		"should log with values passed to keysAndValues": {
-			klogr:         New().V(0),
+			klogr:         New(options...).V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
+			expectedKlogOutput: `"test" akey="avalue"
+`,
 		},
 		"should log with name and values passed to keysAndValues": {
-			klogr:         New().V(0).WithName("me"),
+			klogr:         New(options...).V(0).WithName("me"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: `me "msg"="test"  "akey"="avalue"
 `,
+			expectedKlogOutput: `"me: test" akey="avalue"
+`,
 		},
 		"should log with multiple names and values passed to keysAndValues": {
-			klogr:         New().V(0).WithName("hello").WithName("world"),
+			klogr:         New(options...).V(0).WithName("hello").WithName("world"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: `hello/world "msg"="test"  "akey"="avalue"
 `,
+			expectedKlogOutput: `"hello/world: test" akey="avalue"
+`,
 		},
 		"should not print duplicate keys with the same value": {
-			klogr:         New().V(0),
+			klogr:         New(options...).V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
+			expectedKlogOutput: `"test" akey="avalue"
+`,
 		},
 		"should only print the last duplicate key when the values are passed to Info": {
-			klogr:         New().V(0),
+			klogr:         New(options...).V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue2"
 `,
+			expectedKlogOutput: `"test" akey="avalue2"
+`,
 		},
 		"should only print the duplicate key that is passed to Info if one was passed to the logger": {
-			klogr:         New().WithValues("akey", "avalue"),
+			klogr:         New(options...).WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
+			expectedKlogOutput: `"test" akey="avalue"
+`,
 		},
-		"should sort within logger and parameter key/value pairs and dump the logger pairs first": {
-			klogr:         New().WithValues("akey9", "avalue9", "akey8", "avalue8", "akey1", "avalue1"),
+		"should sort within logger and parameter key/value pairs in the default format and dump the logger pairs first": {
+			klogr:         New(options...).WithValues("akey9", "avalue9", "akey8", "avalue8", "akey1", "avalue1"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey5", "avalue5", "akey4", "avalue4"},
 			expectedOutput: ` "msg"="test" "akey1"="avalue1" "akey8"="avalue8" "akey9"="avalue9" "akey4"="avalue4" "akey5"="avalue5"
 `,
+			expectedKlogOutput: `"test" akey9="avalue9" akey8="avalue8" akey1="avalue1" akey5="avalue5" akey4="avalue4"
+`,
 		},
 		"should only print the key passed to Info when one is already set on the logger": {
-			klogr:         New().WithValues("akey", "avalue"),
+			klogr:         New(options...).WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue2"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue2"
+`,
+			expectedKlogOutput: `"test" akey="avalue2"
 `,
 		},
 		"should correctly handle odd-numbers of KVs": {
@@ -90,36 +107,46 @@ func TestOutput(t *testing.T) {
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue" "akey2"=null
 `,
+			expectedKlogOutput: `"test" akey="avalue" akey2=<nil>
+`,
 		},
 		"should correctly html characters": {
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "<&>"},
 			expectedOutput: ` "msg"="test"  "akey"="<&>"
 `,
+			expectedKlogOutput: `"test" akey="<&>"
+`,
 		},
 		"should correctly handle odd-numbers of KVs in both log values and Info args": {
-			klogr:         New().WithValues("basekey1", "basevar1", "basekey2"),
+			klogr:         New(options...).WithValues("basekey1", "basevar1", "basekey2"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
 			expectedOutput: ` "msg"="test" "basekey1"="basevar1" "basekey2"=null "akey"="avalue" "akey2"=null
 `,
+			expectedKlogOutput: `"test" basekey1="basevar1" basekey2=<nil> akey="avalue" akey2=<nil>
+`,
 		},
 		"should correctly print regular error types": {
-			klogr:         New().V(0),
+			klogr:         New(options...).V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"err", errors.New("whoops")},
 			expectedOutput: ` "msg"="test"  "err"="whoops"
 `,
+			expectedKlogOutput: `"test" err="whoops"
+`,
 		},
-		"should use MarshalJSON if an error type implements it": {
-			klogr:         New().V(0),
+		"should use MarshalJSON in the default format if an error type implements it": {
+			klogr:         New(options...).V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"err", &customErrorJSON{"whoops"}},
 			expectedOutput: ` "msg"="test"  "err"="WHOOPS"
 `,
+			expectedKlogOutput: `"test" err="whoops"
+`,
 		},
 		"should correctly print regular error types when using logr.Error": {
-			klogr: New().V(0),
+			klogr: New(options...).V(0),
 			text:  "test",
 			err:   errors.New("whoops"),
 			// The message is printed to three different log files (info, warning, error), so we see it three times in our output buffer.
@@ -127,13 +154,17 @@ func TestOutput(t *testing.T) {
  "msg"="test" "error"="whoops"  
  "msg"="test" "error"="whoops"  
 `,
+			expectedKlogOutput: `"test" err="whoops"
+"test" err="whoops"
+"test" err="whoops"
+`,
 		},
 	}
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
 			klogr := test.klogr
 			if klogr == nil {
-				klogr = New()
+				klogr = New(options...)
 			}
 
 			// hijack the klog output
@@ -150,9 +181,34 @@ func TestOutput(t *testing.T) {
 			klog.Flush()
 
 			actual := tmpWriteBuffer.String()
-			if actual != test.expectedOutput {
-				t.Errorf("expected %q did not match actual %q", test.expectedOutput, actual)
+			expectedOutput := test.expectedOutput
+			if format == string(FormatKlog) {
+				expectedOutput = test.expectedKlogOutput
 			}
+			if actual != expectedOutput {
+				t.Errorf("expected %q did not match actual %q", expectedOutput, actual)
+			}
+		})
+	}
+}
+
+func TestOutput(t *testing.T) {
+	klog.InitFlags(nil)
+	flag.CommandLine.Set("v", "10")
+	flag.CommandLine.Set("skip_headers", "true")
+	flag.CommandLine.Set("logtostderr", "false")
+	flag.CommandLine.Set("alsologtostderr", "false")
+	flag.CommandLine.Set("stderrthreshold", "10")
+	flag.Parse()
+
+	formats := []string{
+		formatDefault,
+		string(FormatSerialize),
+		string(FormatKlog),
+	}
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			testOutput(t, format)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that klog has support for structured logging, it makes sense to
use that also through klogr. The log output without a structured
logger becomes more readable and key/value semantic is not lost
anymore with a structured logger.

**Special notes for your reviewer**:

Revising the output handling is a breaking change for those
who depend on the traditional output. Therefore this is implemented in
a backward compatible way with a new `NewWithOptions` function.
`New` retains the original behavior.

**Release note**:
```release-note
klogr can be configured to let klog deal with key/value pairs by creating an instance with NewWithOptions
```