### PR TITLE
fix go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
-github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v0.2.1 h1:fV3MLmabKIZ383XifUjFSwcoGee0v9qgPp8wy5svibE=
+github.com/go-logr/logr v0.2.1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=


### PR DESCRIPTION
**What this PR does / why we need it**:

Commit 29a2d649 bumped logr in go.mod without the corresponding change
in go.sum, with the result that any go invocation (for example "go
test .") leads to a modified repo.

**Release note**:
```release-note
NONE
```