### PR TITLE
github: fix apidiff check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version: 1.13.x
       - name: Add GOBIN to PATH
-        run: echo "::add-path::$(go env GOPATH)/bin"
+        run: echo "PATH=$(go env GOPATH)/bin:$PATH" >>$GITHUB_ENV
       - name: Install dependencies
         run: GO111MODULE=off go get golang.org/x/exp/cmd/apidiff
       - name: Checkout old code


### PR DESCRIPTION
**What this PR does / why we need it**:

The ::add-path:: command was
disabled (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). One
possible replacement should be to modify the content of
$GITHUB_ENV (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).

**Release note**:
```release-note
NONE
```