### PR TITLE
Logging via logr.Logger should include severity, file, line

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -913,12 +913,11 @@ func (l *loggingT) output(s severity, log logr.Logger, buf *buffer, file string,
 	}
 	data := buf.Bytes()
 	if log != nil {
-		// TODO: set 'severity' and caller information as structured log info
-		// keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
+		keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
 		if s == errorLog {
-			l.logr.Error(nil, string(data))
+			log.Error(nil, string(data), keysAndValues...)
 		} else {
-			log.Info(string(data))
+			log.Info(string(data), keysAndValues...)
 		}
 	} else if l.toStderr {
 		os.Stderr.Write(data)


### PR DESCRIPTION
**What this PR does / why we need it**:

The `klog.SetLogger` function documentation mentions that log severity and file/line origin will be added as structured fields when `klog` uses a `logr` logger as log sink:

https://github.com/kubernetes/klog/blob/ea3b07f76a038d8ec9a2e52dc9a7840c817cfa8a/klog.go#L860-L867

However that functionality was left unimplemented as an inline TODO:

https://github.com/kubernetes/klog/blob/ea3b07f76a038d8ec9a2e52dc9a7840c817cfa8a/klog.go#L916-L917

This change implements that and adds a test verifying it.

**Special notes for your reviewer**:

N/A

**Release note**:

NONE

(Package now behaves as documented, if that requires a release note, happy to write one)