### PR TITLE
Stderr threshold issue fix

### DIFF
--- a/integration_tests/klog_test.go
+++ b/integration_tests/klog_test.go
@@ -98,7 +98,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 		"everything disabled": {
 			// Nothing, including the trace on fatal, is showing anywhere
 
-			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000"},
+			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
 
 			notExpectedOnStderr: allLogREs,
 		},
@@ -106,7 +106,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything above -stderrthreshold, including the trace on fatal, will
 			// be logged to stderr, even if we set -logtostderr to false.
 
-			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1"},
+			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1", "-alsologtostderrthreshold=1"},
 
 			expectedOnStderr:    res{warningLogRE, errorLogRE, stackTraceRE},
 			notExpectedOnStderr: res{infoLogRE},
@@ -114,7 +114,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 		"with logtostderr only": {
 			// Everything, including the trace on fatal, goes to stderr
 
-			flags: []string{"-logtostderr=true", "-alsologtostderr=false", "-stderrthreshold=1000"},
+			flags: []string{"-logtostderr=true", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 
 			expectedOnStderr: allLogREs,
 		},
@@ -122,7 +122,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the single log file
 
 			logfile: true,
-			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000"},
+			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
 
 			expectedLogFile: true,
 
@@ -133,7 +133,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the log files in the log dir
 
 			logdir: true,
-			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000"},
+			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
 
 			expectedLogDir: true,
 
@@ -145,7 +145,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the log files in the log dir
 
 			logdir: true,
-			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-one_output=true"},
+			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000", "-one_output=true"},
 
 			expectedLogDir: true,
 
@@ -158,7 +158,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// ignored, nothing goes to the log files in the log dir.
 
 			logdir: true,
-			flags:  []string{"-logtostderr=true", "-alsologtostderr=false", "-stderrthreshold=1000"},
+			flags:  []string{"-logtostderr=true", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 
 			expectedOnStderr: allLogREs,
 		},
@@ -168,7 +168,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 
 			logdir:  true,
 			logfile: true,
-			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000"},
+			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
 
 			expectedLogFile: true,
 
@@ -179,7 +179,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the single log file
 			// AND to stderr.
 
-			flags:   []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000"},
+			flags:   []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=0"},
 			logfile: true,
 
 			expectedLogFile: true,
@@ -192,7 +192,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// log dir AND to stderr.
 
 			logdir: true,
-			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000"},
+			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=0"},
 
 			expectedLogDir: true,
 
@@ -205,7 +205,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// log dir AND to stderr.
 
 			logdir: true,
-			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-one_output=true"},
+			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-alsotostderrthreshold=0", "-one_output=true"},
 
 			expectedLogDir: true,
 

--- a/integration_tests/klog_test.go
+++ b/integration_tests/klog_test.go
@@ -98,7 +98,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 		"everything disabled": {
 			// Nothing, including the trace on fatal, is showing anywhere
 
-			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
+			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 
 			notExpectedOnStderr: allLogREs,
 		},
@@ -106,7 +106,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything above -stderrthreshold, including the trace on fatal, will
 			// be logged to stderr, even if we set -logtostderr to false.
 
-			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1", "-alsologtostderrthreshold=1"},
+			flags: []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1"},
 
 			expectedOnStderr:    res{warningLogRE, errorLogRE, stackTraceRE},
 			notExpectedOnStderr: res{infoLogRE},
@@ -122,7 +122,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the single log file
 
 			logfile: true,
-			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
+			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 
 			expectedLogFile: true,
 
@@ -133,7 +133,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the log files in the log dir
 
 			logdir: true,
-			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
+			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 
 			expectedLogDir: true,
 
@@ -145,7 +145,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the log files in the log dir
 
 			logdir: true,
-			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000", "-one_output=true"},
+			flags:  []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000", "-one_output=true"},
 
 			expectedLogDir: true,
 
@@ -168,7 +168,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 
 			logdir:  true,
 			logfile: true,
-			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=1000"},
+			flags:   []string{"-logtostderr=false", "-alsologtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 
 			expectedLogFile: true,
 
@@ -179,7 +179,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// Everything, including the trace on fatal, goes to the single log file
 			// AND to stderr.
 
-			flags:   []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=0"},
+			flags:   []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 			logfile: true,
 
 			expectedLogFile: true,
@@ -192,7 +192,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// log dir AND to stderr.
 
 			logdir: true,
-			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-alsologtostderrthreshold=0"},
+			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=0", "-alsologtostderrthreshold=1000"},
 
 			expectedLogDir: true,
 
@@ -205,7 +205,7 @@ func TestDestinationsWithDifferentFlags(t *testing.T) {
 			// log dir AND to stderr.
 
 			logdir: true,
-			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=1000", "-alsotostderrthreshold=0", "-one_output=true"},
+			flags:  []string{"-alsologtostderr=true", "-logtostderr=false", "-stderrthreshold=0", "-alsotostderrthreshold=1000", "-one_output=true"},
 
 			expectedLogDir: true,
 

--- a/klog.go
+++ b/klog.go
@@ -46,7 +46,7 @@
 //	-stderrthreshold=INFO
 //		Log events at or above this severity are logged to standard
 //		error.
-//	-alsotostderrthreshold=ERROR
+//	-alsologtostderrthreshold=ERROR
 //		Log events at or above this severity are logged to standard
 //		error as well as to files.
 //	-log_dir=""
@@ -95,7 +95,7 @@ import (
 )
 
 // severity identifies the sort of log: info, warning etc. It also implements the
-// flag.Value interface. The -stderrthreshold and -alsotostderrthreshold flags are
+// flag.Value interface. The -stderrthreshold and -alsologtostderrthreshold flags are
 // of type severity and should be modified only through the flag.Value interface.
 // The values match the corresponding constants in C++.
 type severity int32 // sync/atomic int32
@@ -440,7 +440,7 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.BoolVar(&logging.oneOutput, "one_output", logging.oneOutput, "If true, only write logs to their native severity level (vs also writing to each lower severity level)")
 	flagset.BoolVar(&logging.skipLogHeaders, "skip_log_headers", logging.skipLogHeaders, "If true, avoid headers when opening log files")
 	flagset.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
-	flagset.Var(&logging.alsoToStderrThreshold, "alsotostderrthreshold", "logs at or above this threshold go to stderr as well as files")
+	flagset.Var(&logging.alsoToStderrThreshold, "alsologtostderrthreshold", "logs at or above this threshold go to stderr as well as files")
 	flagset.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	flagset.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
 }
@@ -460,7 +460,7 @@ type loggingT struct {
 
 	// Level flag. Handled atomically.
 	stderrThreshold       severity // The -stderrthreshold flag.
-	alsoToStderrThreshold severity // The -alsotostderrthreshold flag.
+	alsoToStderrThreshold severity // The -alsologtostderrthreshold flag.
 
 	// freeList is a list of byte buffers, maintained under freeListMu.
 	freeList *buffer

--- a/klog_test.go
+++ b/klog_test.go
@@ -1427,19 +1427,20 @@ func (l *testLogr) WithValues(...interface{}) logr.Logger {
 
 // existedFlag contains all existed flag, without KlogPrefix
 var existedFlag = map[string]struct{}{
-	"log_dir":           {},
-	"add_dir_header":    {},
-	"alsologtostderr":   {},
-	"log_backtrace_at":  {},
-	"log_file":          {},
-	"log_file_max_size": {},
-	"logtostderr":       {},
-	"one_output":        {},
-	"skip_headers":      {},
-	"skip_log_headers":  {},
-	"stderrthreshold":   {},
-	"v":                 {},
-	"vmodule":           {},
+	"log_dir":                  {},
+	"add_dir_header":           {},
+	"alsologtostderr":          {},
+	"alsologtostderrthreshold": {},
+	"log_backtrace_at":         {},
+	"log_file":                 {},
+	"log_file_max_size":        {},
+	"logtostderr":              {},
+	"one_output":               {},
+	"skip_headers":             {},
+	"skip_log_headers":         {},
+	"stderrthreshold":          {},
+	"v":                        {},
+	"vmodule":                  {},
 }
 
 // KlogPrefix define new flag prefix


### PR DESCRIPTION
**What this PR does / why we need it**:

This is my proposal to address these issues: https://github.com/kubernetes/klog/issues/54 and https://github.com/kubernetes/klog/issues/21

History of this bug:
https://github.com/kubernetes/klog/pull/31
https://github.com/kubernetes/klog/pull/42
https://github.com/kubernetes/klog/pull/50

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #212 

**Special notes for your reviewer**:

I added a further flag to decouple the behaviors between `alsoToStderr` and the default level of `toStderr`.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```