### PR TITLE
Fix cases where KMetadata interface has nil object

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -81,6 +81,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1578,6 +1579,9 @@ type KMetadata interface {
 // KObj returns ObjectRef from ObjectMeta
 func KObj(obj KMetadata) ObjectRef {
 	if obj == nil {
+		return ObjectRef{}
+	}
+	if val := reflect.ValueOf(obj); val.Kind() == reflect.Ptr && val.IsNil() {
 		return ObjectRef{}
 	}
 


### PR DESCRIPTION
DO NOT MERGE, this is one of the alternatives considered to fix https://github.com/kubernetes/kubernetes/issues/100155

**What this PR does / why we need it**:

Fixes passing `nil` object to `klog.KObj`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/100155

**Special notes for your reviewer**:

Added benchmark run them with `go test -bench=BenchmarkKObj -count=100 -benchmem -run=^$` and got results analysed by [benchstat](https://github.com/golang/perf/tree/master/cmd/benchstat):
```
name    old time/op    new time/op    delta
KObj-8    7.04ns ± 6%    7.50ns ± 8%  +6.57%  (p=0.000 n=89+93)

name    old alloc/op   new alloc/op   delta
KObj-8     0.00B          0.00B         ~     (all equal)

name    old allocs/op  new allocs/op  delta
KObj-8      0.00           0.00         ~     (all equal)
```

We see around 19% worse performance by introducing reflections, still looks acceptable.

**Release note**:
```release-note
NONE
```