### PR TITLE
logcheck: check usage of format specifier in structured log functions

### DIFF
--- a/hack/tools/logcheck/testdata/data.go
+++ b/hack/tools/logcheck/testdata/data.go
@@ -39,6 +39,7 @@ func printUnstructuredLog() {
 	klog.Fatalf("test log")          // want `unstructured logging function "Fatalf" should not be used`
 	klog.Fatalln("test log")         // want `unstructured logging function "Fatalln" should not be used`
 	klog.FatalDepth(1, "test log")   // want `unstructured logging function "FatalDepth" should not be used`
+
 }
 
 func printStructuredLog() {
@@ -53,4 +54,6 @@ func printStructuredLog() {
 	klog.InfoS("Starting container in a pod", map[string]string{"test1": "value"}, "containerID") // want `Key positional arguments are expected to be inlined constant strings. `
 	testKey := "a"
 	klog.ErrorS(nil, "Starting container in a pod", testKey, "containerID") // want `Key positional arguments are expected to be inlined constant strings. `
+	klog.InfoS("test: %s", "testname")                                      // want `structured logging function "InfoS" should not use format specifier "%s"`
+	klog.ErrorS(nil, "test no.: %d", 1)                                     // want `structured logging function "ErrorS" should not use format specifier "%d"`
 }


### PR DESCRIPTION
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
logcheck: check usage of format specifier in structured logging functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #218 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```