### PR TITLE
[WIP]The log file is rebuilt when it is deleted or moved

### DIFF
--- a/klog_test.go
+++ b/klog_test.go
@@ -729,6 +729,34 @@ func TestInitFlags(t *testing.T) {
 	}
 }
 
+func TestRebuildFile(t *testing.T) {
+	InitFlags(nil)
+	logFile := "/tmp/test-rebuild-file.log"
+	// By default klog writes to stderr. Setting logtostderr to false makes klog
+	// write to a log file.
+	flag.Set("logtostderr", "false")
+	flag.Set("log_file", logFile)
+	flag.Parse()
+
+	InfoS("nice to meet you !")
+	if err := os.Remove(logFile); err != nil {
+		t.Fatal(err)
+	}
+	rebuildContent := "This is a test file for the test log rebuild."
+	InfoS(rebuildContent)
+	if !exists(logFile) {
+		t.Fatalf("Test log rebuild failed for file: %s does not exist", logFile)
+	}
+	logging.flushAll()
+	b, err := ioutil.ReadFile(logging.logFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(b), rebuildContent) {
+		t.Fatalf("got %s, missing expected Info log: %s", string(b), rebuildContent)
+	}
+}
+
 func TestInfoObjectRef(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The log file is rebuilt when it is deleted or moved


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubernetes/issues/100478

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```