### PR TITLE
make SetLogger thread-safe

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -861,6 +861,9 @@ func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
 //   ...
 //   klog.SetLogger(zapr.NewLogger(zapLog))
 func SetLogger(logr logr.Logger) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+
 	logging.logr = logr
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`logging.logr` is being used by more than one functions `Error/Info/Warning/...`, at the same time, it can be set by function `SetLogger`, so thread-safe should be cared about, just like the other set functions `SetOutput/SetLogFilter/...`. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>
