### PR TITLE
RFC: testinglogger: per-test, structured logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module k8s.io/klog/v2
 
 go 1.13
 
-require github.com/go-logr/logr v1.0.0
+require github.com/go-logr/logr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,9 @@ github.com/go-logr/logr v1.0.0-rc1 h1:+ul9F74rBkPajeP8m4o3o0tiglmzNFsPnuhYyBCQ0S
 github.com/go-logr/logr v1.0.0-rc1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
 github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.1.0 h1:nAbevmWlS2Ic4m4+/An5NXkaGqlqpbBgdcuThZxnZyI=
+github.com/go-logr/logr v1.1.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/pohly/logr v1.0.1-0.20210804074427-848189eadc0d h1:W5MSfGeobmnps+JKbgMOXdLXCbctLtWxYGpB+hRtLvA=
+github.com/pohly/logr v1.0.1-0.20210804074427-848189eadc0d/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/pohly/logr v1.0.1-0.20210804085709-7b55927b8b51 h1:p5UXTXqCMThQHB1fFcLDvyzbmpCiyoAxjm1V/LaOB1k=
+github.com/pohly/logr v1.0.1-0.20210804085709-7b55927b8b51/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/serialize/keyvalues.go
+++ b/internal/serialize/keyvalues.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serialize
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// TrimDuplicates deduplicates elements provided in multiple key/value tuple
+// slices, whilst maintaining the distinction between where the items are
+// contained.
+func TrimDuplicates(kvLists ...[]interface{}) [][]interface{} {
+	// maintain a map of all seen keys
+	seenKeys := map[interface{}]struct{}{}
+	// build the same number of output slices as inputs
+	outs := make([][]interface{}, len(kvLists))
+	// iterate over the input slices backwards, as 'later' kv specifications
+	// of the same key will take precedence over earlier ones
+	for i := len(kvLists) - 1; i >= 0; i-- {
+		// initialise this output slice
+		outs[i] = []interface{}{}
+		// obtain a reference to the kvList we are processing
+		kvList := kvLists[i]
+
+		// start iterating at len(kvList) - 2 (i.e. the 2nd last item) for
+		// slices that have an even number of elements.
+		// We add (len(kvList) % 2) here to handle the case where there is an
+		// odd number of elements in a kvList.
+		// If there is an odd number, then the last element in the slice will
+		// have the value 'null'.
+		for i2 := len(kvList) - 2 + (len(kvList) % 2); i2 >= 0; i2 -= 2 {
+			k := kvList[i2]
+			// if we have already seen this key, do not include it again
+			if _, ok := seenKeys[k]; ok {
+				continue
+			}
+			// make a note that we've observed a new key
+			seenKeys[k] = struct{}{}
+			// attempt to obtain the value of the key
+			var v interface{}
+			// i2+1 should only ever be out of bounds if we handling the first
+			// iteration over a slice with an odd number of elements
+			if i2+1 < len(kvList) {
+				v = kvList[i2+1]
+			}
+			// add this KV tuple to the *start* of the output list to maintain
+			// the original order as we are iterating over the slice backwards
+			outs[i] = append([]interface{}{k, v}, outs[i]...)
+		}
+	}
+	return outs
+}
+
+const missingValue = "(MISSING)"
+
+// KVListFormat serializes all key/value pairs into the provided buffer.
+// A space gets inserted before the first pair and between each pair.
+func KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
+	for i := 0; i < len(keysAndValues); i += 2 {
+		var v interface{}
+		k := keysAndValues[i]
+		if i+1 < len(keysAndValues) {
+			v = keysAndValues[i+1]
+		} else {
+			v = missingValue
+		}
+		b.WriteByte(' ')
+
+		switch v.(type) {
+		case string, error:
+			b.WriteString(fmt.Sprintf("%s=%q", k, v))
+		case []byte:
+			b.WriteString(fmt.Sprintf("%s=%+q", k, v))
+		default:
+			if _, ok := v.(fmt.Stringer); ok {
+				b.WriteString(fmt.Sprintf("%s=%q", k, v))
+			} else {
+				b.WriteString(fmt.Sprintf("%s=%+v", k, v))
+			}
+		}
+	}
+}

--- a/internal/serialize/keyvalues_test.go
+++ b/internal/serialize/keyvalues_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serialize_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/test"
+)
+
+// Test that kvListFormat works as advertised.
+func TestKvListFormat(t *testing.T) {
+	var testKVList = []struct {
+		keysValues []interface{}
+		want       string
+	}{
+		{
+			keysValues: []interface{}{"pod", "kubedns"},
+			want:       " pod=\"kubedns\"",
+		},
+		{
+			keysValues: []interface{}{"pod", "kubedns", "update", true},
+			want:       " pod=\"kubedns\" update=true",
+		},
+		{
+			keysValues: []interface{}{"pod", "kubedns", "spec", struct {
+				X int
+				Y string
+				N time.Time
+			}{X: 76, Y: "strval", N: time.Date(2006, 1, 2, 15, 4, 5, .067890e9, time.UTC)}},
+			want: " pod=\"kubedns\" spec={X:76 Y:strval N:2006-01-02 15:04:05.06789 +0000 UTC}",
+		},
+		{
+			keysValues: []interface{}{"pod", "kubedns", "values", []int{8, 6, 7, 5, 3, 0, 9}},
+			want:       " pod=\"kubedns\" values=[8 6 7 5 3 0 9]",
+		},
+		{
+			keysValues: []interface{}{"pod", "kubedns", "values", []string{"deployment", "svc", "configmap"}},
+			want:       " pod=\"kubedns\" values=[deployment svc configmap]",
+		},
+		{
+			keysValues: []interface{}{"pod", "kubedns", "bytes", []byte("test case for byte array")},
+			want:       " pod=\"kubedns\" bytes=\"test case for byte array\"",
+		},
+		{
+			keysValues: []interface{}{"pod", "kubedns", "bytes", []byte("��=� ⌘")},
+			want:       " pod=\"kubedns\" bytes=\"\\ufffd\\ufffd=\\ufffd \\u2318\"",
+		},
+		{
+			keysValues: []interface{}{"pod", "kubedns", "maps", map[string]int{"three": 4}},
+			want:       " pod=\"kubedns\" maps=map[three:4]",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.KRef("kube-system", "kubedns"), "status", "ready"},
+			want:       " pod=\"kube-system/kubedns\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.KRef("", "kubedns"), "status", "ready"},
+			want:       " pod=\"kubedns\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.KObj(test.KMetadataMock{Name: "test-name", NS: "test-ns"}), "status", "ready"},
+			want:       " pod=\"test-ns/test-name\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.KObj(test.KMetadataMock{Name: "test-name", NS: ""}), "status", "ready"},
+			want:       " pod=\"test-name\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.KObj(nil), "status", "ready"},
+			want:       " pod=\"\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.KObj((*test.PtrKMetadataMock)(nil)), "status", "ready"},
+			want:       " pod=\"\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.KObj((*test.KMetadataMock)(nil)), "status", "ready"},
+			want:       " pod=\"\" status=\"ready\"",
+		},
+	}
+
+	for _, d := range testKVList {
+		b := &bytes.Buffer{}
+		serialize.KVListFormat(b, d.keysValues...)
+		if b.String() != d.want {
+			t.Errorf("KVListFormat error:\n got:\n\t%s\nwant:\t%s", b.String(), d.want)
+		}
+	}
+}

--- a/internal/test/mock.go
+++ b/internal/test/mock.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package test contains common code for klog tests.
+package test
+
+type KMetadataMock struct {
+	Name, NS string
+}
+
+func (m KMetadataMock) GetName() string {
+	return m.Name
+}
+func (m KMetadataMock) GetNamespace() string {
+	return m.NS
+}
+
+type PtrKMetadataMock struct {
+	Name, NS string
+}
+
+func (m *PtrKMetadataMock) GetName() string {
+	return m.Name
+}
+func (m *PtrKMetadataMock) GetNamespace() string {
+	return m.NS
+}

--- a/klog.go
+++ b/klog.go
@@ -90,6 +90,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/internal/serialize"
 )
 
 // severity identifies the sort of log: info, warning etc. It also implements
@@ -807,36 +809,8 @@ func (l *loggingT) printS(err error, s severity, depth int, msg string, keysAndV
 		b.WriteByte(' ')
 		b.WriteString(fmt.Sprintf("err=%q", err.Error()))
 	}
-	kvListFormat(b, keysAndValues...)
+	serialize.KVListFormat(b, keysAndValues...)
 	l.printDepth(s, logging.logr, nil, depth+1, b)
-}
-
-const missingValue = "(MISSING)"
-
-func kvListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
-	for i := 0; i < len(keysAndValues); i += 2 {
-		var v interface{}
-		k := keysAndValues[i]
-		if i+1 < len(keysAndValues) {
-			v = keysAndValues[i+1]
-		} else {
-			v = missingValue
-		}
-		b.WriteByte(' ')
-
-		switch v.(type) {
-		case string, error:
-			b.WriteString(fmt.Sprintf("%s=%q", k, v))
-		case []byte:
-			b.WriteString(fmt.Sprintf("%s=%+q", k, v))
-		default:
-			if _, ok := v.(fmt.Stringer); ok {
-				b.WriteString(fmt.Sprintf("%s=%q", k, v))
-			} else {
-				b.WriteString(fmt.Sprintf("%s=%+v", k, v))
-			}
-		}
-	}
 }
 
 // redirectBuffer is used to set an alternate destination for the logs

--- a/klog_test.go
+++ b/klog_test.go
@@ -35,6 +35,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/internal/test"
 )
 
 // TODO: This test package should be refactored so that tests cannot
@@ -633,7 +635,7 @@ func BenchmarkKRef(b *testing.B) {
 }
 
 func BenchmarkKObj(b *testing.B) {
-	a := kMetadataMock{name: "a", ns: "a"}
+	a := test.KMetadataMock{Name: "a", NS: "a"}
 	var r ObjectRef
 	for i := 0; i < b.N; i++ {
 		r = KObj(&a)
@@ -771,28 +773,6 @@ func TestInfoObjectRef(t *testing.T) {
 	}
 }
 
-type kMetadataMock struct {
-	name, ns string
-}
-
-func (m kMetadataMock) GetName() string {
-	return m.name
-}
-func (m kMetadataMock) GetNamespace() string {
-	return m.ns
-}
-
-type ptrKMetadataMock struct {
-	name, ns string
-}
-
-func (m *ptrKMetadataMock) GetName() string {
-	return m.name
-}
-func (m *ptrKMetadataMock) GetNamespace() string {
-	return m.ns
-}
-
 func TestKObj(t *testing.T) {
 	tests := []struct {
 		name string
@@ -801,17 +781,17 @@ func TestKObj(t *testing.T) {
 	}{
 		{
 			name: "nil passed as pointer KMetadata implementation",
-			obj:  (*ptrKMetadataMock)(nil),
+			obj:  (*test.PtrKMetadataMock)(nil),
 			want: ObjectRef{},
 		},
 		{
 			name: "empty struct passed as non-pointer KMetadata implementation",
-			obj:  kMetadataMock{},
+			obj:  test.KMetadataMock{},
 			want: ObjectRef{},
 		},
 		{
 			name: "nil pointer passed to non-pointer KMetadata implementation",
-			obj:  (*kMetadataMock)(nil),
+			obj:  (*test.KMetadataMock)(nil),
 			want: ObjectRef{},
 		},
 		{
@@ -821,7 +801,7 @@ func TestKObj(t *testing.T) {
 		},
 		{
 			name: "with ns",
-			obj:  &kMetadataMock{"test-name", "test-ns"},
+			obj:  &test.KMetadataMock{Name: "test-name", NS: "test-ns"},
 			want: ObjectRef{
 				Name:      "test-name",
 				Namespace: "test-ns",
@@ -829,7 +809,7 @@ func TestKObj(t *testing.T) {
 		},
 		{
 			name: "without ns",
-			obj:  &kMetadataMock{"test-name", ""},
+			obj:  &test.KMetadataMock{Name: "test-name", NS: ""},
 			want: ObjectRef{
 				Name: "test-name",
 			},
@@ -1033,87 +1013,6 @@ func TestErrorS(t *testing.T) {
 			if contents(errorLog) != want {
 				t.Errorf("ErrorS has wrong format: \n got:\t%s\nwant:\t%s", contents(errorLog), want)
 			}
-		}
-	}
-}
-
-// Test that kvListFormat works as advertised.
-func TestKvListFormat(t *testing.T) {
-	var testKVList = []struct {
-		keysValues []interface{}
-		want       string
-	}{
-		{
-			keysValues: []interface{}{"pod", "kubedns"},
-			want:       " pod=\"kubedns\"",
-		},
-		{
-			keysValues: []interface{}{"pod", "kubedns", "update", true},
-			want:       " pod=\"kubedns\" update=true",
-		},
-		{
-			keysValues: []interface{}{"pod", "kubedns", "spec", struct {
-				X int
-				Y string
-				N time.Time
-			}{X: 76, Y: "strval", N: time.Date(2006, 1, 2, 15, 4, 5, .067890e9, time.UTC)}},
-			want: " pod=\"kubedns\" spec={X:76 Y:strval N:2006-01-02 15:04:05.06789 +0000 UTC}",
-		},
-		{
-			keysValues: []interface{}{"pod", "kubedns", "values", []int{8, 6, 7, 5, 3, 0, 9}},
-			want:       " pod=\"kubedns\" values=[8 6 7 5 3 0 9]",
-		},
-		{
-			keysValues: []interface{}{"pod", "kubedns", "values", []string{"deployment", "svc", "configmap"}},
-			want:       " pod=\"kubedns\" values=[deployment svc configmap]",
-		},
-		{
-			keysValues: []interface{}{"pod", "kubedns", "bytes", []byte("test case for byte array")},
-			want:       " pod=\"kubedns\" bytes=\"test case for byte array\"",
-		},
-		{
-			keysValues: []interface{}{"pod", "kubedns", "bytes", []byte("��=� ⌘")},
-			want:       " pod=\"kubedns\" bytes=\"\\ufffd\\ufffd=\\ufffd \\u2318\"",
-		},
-		{
-			keysValues: []interface{}{"pod", "kubedns", "maps", map[string]int{"three": 4}},
-			want:       " pod=\"kubedns\" maps=map[three:4]",
-		},
-		{
-			keysValues: []interface{}{"pod", KRef("kube-system", "kubedns"), "status", "ready"},
-			want:       " pod=\"kube-system/kubedns\" status=\"ready\"",
-		},
-		{
-			keysValues: []interface{}{"pod", KRef("", "kubedns"), "status", "ready"},
-			want:       " pod=\"kubedns\" status=\"ready\"",
-		},
-		{
-			keysValues: []interface{}{"pod", KObj(kMetadataMock{"test-name", "test-ns"}), "status", "ready"},
-			want:       " pod=\"test-ns/test-name\" status=\"ready\"",
-		},
-		{
-			keysValues: []interface{}{"pod", KObj(kMetadataMock{"test-name", ""}), "status", "ready"},
-			want:       " pod=\"test-name\" status=\"ready\"",
-		},
-		{
-			keysValues: []interface{}{"pod", KObj(nil), "status", "ready"},
-			want:       " pod=\"\" status=\"ready\"",
-		},
-		{
-			keysValues: []interface{}{"pod", KObj((*ptrKMetadataMock)(nil)), "status", "ready"},
-			want:       " pod=\"\" status=\"ready\"",
-		},
-		{
-			keysValues: []interface{}{"pod", KObj((*kMetadataMock)(nil)), "status", "ready"},
-			want:       " pod=\"\" status=\"ready\"",
-		},
-	}
-
-	for _, d := range testKVList {
-		b := &bytes.Buffer{}
-		kvListFormat(b, d.keysValues...)
-		if b.String() != d.want {
-			t.Errorf("kvlist format error:\n got:\n\t%s\nwant:\t%s", b.String(), d.want)
 		}
 	}
 }
@@ -1775,13 +1674,13 @@ func TestKObjs(t *testing.T) {
 	}{
 		{
 			name: "test for KObjs function with KMetadata slice",
-			obj: []kMetadataMock{
+			obj: []test.KMetadataMock{
 				{
-					name: "kube-dns",
-					ns:   "kube-system",
+					Name: "kube-dns",
+					NS:   "kube-system",
 				},
 				{
-					name: "mi-conf",
+					Name: "mi-conf",
 				},
 				{},
 			},
@@ -1798,13 +1697,13 @@ func TestKObjs(t *testing.T) {
 		},
 		{
 			name: "test for KObjs function with KMetadata pointer slice",
-			obj: []*kMetadataMock{
+			obj: []*test.KMetadataMock{
 				{
-					name: "kube-dns",
-					ns:   "kube-system",
+					Name: "kube-dns",
+					NS:   "kube-system",
 				},
 				{
-					name: "mi-conf",
+					Name: "mi-conf",
 				},
 				nil,
 			},

--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -6,10 +6,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/go-logr/logr"
-	"k8s.io/klog/v2"
 	"sort"
 	"strings"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/internal/serialize"
 )
 
 // Option is a functional option that reconfigures the logger created with New.
@@ -70,51 +73,6 @@ func (l *klogger) Init(info logr.RuntimeInfo) {
 	l.callDepth += info.CallDepth
 }
 
-// trimDuplicates will deduplicate elements provided in multiple KV tuple
-// slices, whilst maintaining the distinction between where the items are
-// contained.
-func trimDuplicates(kvLists ...[]interface{}) [][]interface{} {
-	// maintain a map of all seen keys
-	seenKeys := map[interface{}]struct{}{}
-	// build the same number of output slices as inputs
-	outs := make([][]interface{}, len(kvLists))
-	// iterate over the input slices backwards, as 'later' kv specifications
-	// of the same key will take precedence over earlier ones
-	for i := len(kvLists) - 1; i >= 0; i-- {
-		// initialise this output slice
-		outs[i] = []interface{}{}
-		// obtain a reference to the kvList we are processing
-		kvList := kvLists[i]
-
-		// start iterating at len(kvList) - 2 (i.e. the 2nd last item) for
-		// slices that have an even number of elements.
-		// We add (len(kvList) % 2) here to handle the case where there is an
-		// odd number of elements in a kvList.
-		// If there is an odd number, then the last element in the slice will
-		// have the value 'null'.
-		for i2 := len(kvList) - 2 + (len(kvList) % 2); i2 >= 0; i2 -= 2 {
-			k := kvList[i2]
-			// if we have already seen this key, do not include it again
-			if _, ok := seenKeys[k]; ok {
-				continue
-			}
-			// make a note that we've observed a new key
-			seenKeys[k] = struct{}{}
-			// attempt to obtain the value of the key
-			var v interface{}
-			// i2+1 should only ever be out of bounds if we handling the first
-			// iteration over a slice with an odd number of elements
-			if i2+1 < len(kvList) {
-				v = kvList[i2+1]
-			}
-			// add this KV tuple to the *start* of the output list to maintain
-			// the original order as we are iterating over the slice backwards
-			outs[i] = append([]interface{}{k, v}, outs[i]...)
-		}
-	}
-	return outs
-}
-
 func flatten(kvList ...interface{}) string {
 	keys := make([]string, 0, len(kvList))
 	vals := make(map[string]interface{}, len(kvList))
@@ -161,12 +119,12 @@ func (l klogger) Info(level int, msg string, kvList ...interface{}) {
 	switch l.format {
 	case FormatSerialize:
 		msgStr := flatten("msg", msg)
-		trimmed := trimDuplicates(l.values, kvList)
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
 		fixedStr := flatten(trimmed[0]...)
 		userStr := flatten(trimmed[1]...)
 		klog.InfoDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", fixedStr, " ", userStr)
 	case FormatKlog:
-		trimmed := trimDuplicates(l.values, kvList)
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
 		if l.prefix != "" {
 			msg = l.prefix + ": " + msg
 		}
@@ -187,12 +145,12 @@ func (l klogger) Error(err error, msg string, kvList ...interface{}) {
 	switch l.format {
 	case FormatSerialize:
 		errStr := flatten("error", loggableErr)
-		trimmed := trimDuplicates(l.values, kvList)
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
 		fixedStr := flatten(trimmed[0]...)
 		userStr := flatten(trimmed[1]...)
 		klog.ErrorDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", errStr, " ", fixedStr, " ", userStr)
 	case FormatKlog:
-		trimmed := trimDuplicates(l.values, kvList)
+		trimmed := serialize.TrimDuplicates(l.values, kvList)
 		if l.prefix != "" {
 			msg = l.prefix + ": " + msg
 		}

--- a/testinglogger/example/example_test.go
+++ b/testinglogger/example/example_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package example
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	logrtesting "github.com/go-logr/logr/testing"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/testinglogger"
+)
+
+func TestKlog(t *testing.T) {
+	log := testinglogger.New(t)
+	exampleOutput(log)
+}
+
+func TestLogr(t *testing.T) {
+	log := logrtesting.NewTestLoggerWithOptions(t,
+		logrtesting.Options{
+			LogTimestamp: true,
+			Verbosity:    5,
+		},
+	)
+	exampleOutput(log)
+}
+
+type pair struct {
+	a, b int
+}
+
+func (p pair) String() string {
+	return fmt.Sprintf("(%d, %d)", p.a, p.b)
+}
+
+var _ fmt.Stringer = pair{}
+
+type err struct {
+	msg string
+}
+
+func (e err) Error() string {
+	return "failed: " + e.msg
+}
+
+var _ error = err{}
+
+type kmeta struct {
+	name, namespace string
+}
+
+func (k kmeta) GetName() string {
+	return k.name
+}
+
+func (k kmeta) GetNamespace() string {
+	return k.namespace
+}
+
+var _ klog.KMetadata = kmeta{}
+
+func exampleOutput(log logr.Logger) {
+	log.Info("hello world")
+	log.Error(err{msg: "some error"}, "failed")
+	log.V(1).Info("verbosity 1")
+	log.WithName("main").WithName("helper").Info("with prefix")
+	log.Info("key/value pairs",
+		"int", 1,
+		"float", 2.0,
+		"pair", pair{a: 1, b: 2},
+		"kobj", klog.KObj(kmeta{name: "sally", namespace: "kube-system"}),
+	)
+}

--- a/testinglogger/testinglogger.go
+++ b/testinglogger/testinglogger.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testinglogger contains an implementation of the logr interface
+// which is logging through a function like testing.TB.Log function.
+// Therefore it can be used in standard Go tests and Gingko test suites
+// to ensure that output is associated with the currently running test.
+//
+// Serialization of the structured log parameters is done in the same way
+// as for klog.InfoS.
+//
+package testinglogger
+
+import (
+	"bytes"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/internal/serialize"
+)
+
+// Logger is the relevant subset of testing.TB.
+type Logger interface {
+	Helper()
+	Log(args ...interface{})
+}
+
+// New constructs a new logger for the given test interface.
+func New(l Logger) logr.Logger {
+	return logr.New(&tlogger{
+		l:      l,
+		prefix: "",
+		values: nil,
+	})
+}
+
+type tlogger struct {
+	l      Logger
+	prefix string
+	values []interface{}
+}
+
+func (l *tlogger) clone() *tlogger {
+	return &tlogger{
+		l:      l.l,
+		prefix: l.prefix,
+		values: copySlice(l.values),
+	}
+}
+
+func copySlice(in []interface{}) []interface{} {
+	out := make([]interface{}, len(in))
+	copy(out, in)
+	return out
+}
+
+func (l *tlogger) Init(info logr.RuntimeInfo) {
+}
+
+func (l *tlogger) GetCallStackHelper() func() {
+	return l.l.Helper
+}
+
+func (l *tlogger) Info(level int, msg string, kvList ...interface{}) {
+	l.l.Helper()
+	buffer := &bytes.Buffer{}
+	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	serialize.KVListFormat(buffer, trimmed[0]...)
+	serialize.KVListFormat(buffer, trimmed[1]...)
+	l.log("INFO", msg, buffer)
+}
+
+func (l *tlogger) Enabled(level int) bool {
+	return true
+}
+
+func (l *tlogger) Error(err error, msg string, kvList ...interface{}) {
+	l.l.Helper()
+	buffer := &bytes.Buffer{}
+	serialize.KVListFormat(buffer, "err", err)
+	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	serialize.KVListFormat(buffer, trimmed[0]...)
+	serialize.KVListFormat(buffer, trimmed[1]...)
+	l.log("ERROR", msg, buffer)
+}
+
+func (l *tlogger) log(what, msg string, buffer *bytes.Buffer) {
+	l.l.Helper()
+	args := []interface{}{what}
+	if l.prefix != "" {
+		args = append(args, l.prefix+":")
+	}
+	args = append(args, msg)
+	if buffer.Len() > 0 {
+		// Skip leading space inserted by serialize.KVListFormat.
+		args = append(args, string(buffer.Bytes()[1:]))
+	}
+	l.l.Log(args...)
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l *tlogger) WithName(name string) logr.LogSink {
+	new := l.clone()
+	if len(l.prefix) > 0 {
+		new.prefix = l.prefix + "/"
+	}
+	new.prefix += name
+	return new
+}
+
+func (l *tlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	new := l.clone()
+	new.values = append(new.values, kvList...)
+	return new
+}
+
+var _ logr.LogSink = &tlogger{}
+var _ logr.CallStackHelperLogSink = &tlogger{}

--- a/testinglogger/testinglogger_test.go
+++ b/testinglogger/testinglogger_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testinglogger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestInfo(t *testing.T) {
+	tests := map[string]struct {
+		text           string
+		withValues     []interface{}
+		keysAndValues  []interface{}
+		names          []string
+		err            error
+		expectedOutput string
+	}{
+		"should log with values passed to keysAndValues": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO test akey="avalue"
+`,
+		},
+		"should support single name": {
+			names:         []string{"hello"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO hello: test akey="avalue"
+`,
+		},
+		"should support multiple names": {
+			names:         []string{"hello", "world"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO hello/world: test akey="avalue"
+`,
+		},
+		"should not print duplicate keys with the same value": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
+			expectedOutput: `INFO test akey="avalue"
+`,
+		},
+		"should only print the last duplicate key when the values are passed to Info": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
+			expectedOutput: `INFO test akey="avalue2"
+`,
+		},
+		"should only print the duplicate key that is passed to Info if one was passed to the logger": {
+			withValues:    []interface{}{"akey", "avalue"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO test akey="avalue"
+`,
+		},
+		"should only print the key passed to Info when one is already set on the logger": {
+			withValues:    []interface{}{"akey", "avalue"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue2"},
+			expectedOutput: `INFO test akey="avalue2"
+`,
+		},
+		"should correctly handle odd-numbers of KVs": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
+			expectedOutput: `INFO test akey="avalue" akey2=<nil>
+`,
+		},
+		"should correctly html characters": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "<&>"},
+			expectedOutput: `INFO test akey="<&>"
+`,
+		},
+		"should correctly handle odd-numbers of KVs in both log values and Info args": {
+			withValues:    []interface{}{"basekey1", "basevar1", "basekey2"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
+			expectedOutput: `INFO test basekey1="basevar1" basekey2=<nil> akey="avalue" akey2=<nil>
+`,
+		},
+		"should correctly print regular error types": {
+			text:          "test",
+			keysAndValues: []interface{}{"err", errors.New("whoops")},
+			expectedOutput: `INFO test err="whoops"
+`,
+		},
+		"should correctly print regular error types when using logr.Error": {
+			text: "test",
+			err:  errors.New("whoops"),
+			expectedOutput: `ERROR test err="whoops"
+`,
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			var buffer logToBuf
+			klogr := New(&buffer)
+			for _, name := range test.names {
+				klogr = klogr.WithName(name)
+			}
+			klogr = klogr.WithValues(test.withValues...)
+
+			if test.err != nil {
+				klogr.Error(test.err, test.text, test.keysAndValues...)
+			} else {
+				klogr.Info(test.text, test.keysAndValues...)
+			}
+
+			actual := buffer.String()
+			if actual != test.expectedOutput {
+				t.Errorf("expected %q did not match actual %q", test.expectedOutput, actual)
+			}
+		})
+	}
+}
+
+func TestCallDepth(t *testing.T) {
+	klogr := New(t)
+	klogr.Info("hello world")
+}
+
+type logToBuf struct {
+	bytes.Buffer
+}
+
+func (l *logToBuf) Helper() {
+}
+
+func (l *logToBuf) Log(args ...interface{}) {
+	for i, arg := range args {
+		if i > 0 {
+			l.Write([]byte(" "))
+		}
+		l.Write([]byte(fmt.Sprintf("%s", arg)))
+	}
+	l.Write([]byte("\n"))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This logr implementation can be used in tests to ensure that output
is associated with the currently running test. Compared to using the
global klog instance in a standard Go test that has some advantages:

- Log messages are associated with the currently running test.
  Test can run in parallel without interleaving their output.
- Log output is only printed when a test fails, unless "go test -v"
  is used.
- Because of that, the logger can print all log messages. It is
  not necessary to add klog.InitFlags to tests and then remember
  to increase the log level when invoking the test.

**Special notes for your reviewer**:

The motivation for hosting this logger in klog is that it shares code with klogr and klog itself and that it may also be useful for others.

I originally wrote this for PMEM-CSI (copying some code from klog), but now would also like to use it in external-provisioner and thus need a way to share it properly.

I envision that this might also become relevant for Kubernetes, once we figure out how to pass a logr instance around instead of always using the global klog. 

**Release note**:
```release-note
new testinglogger: per-test, structured logging
```