### PR TITLE
Remove directxman12 from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,5 +15,4 @@ approvers:
   - tallclair
   - piosz
   - brancz
-  - DirectXMan12
   - lavalamp


### PR DESCRIPTION
As per
https://groups.google.com/g/kubebuilder/c/-5hOFa_adr4/m/Sp_Zb755AwAJ,
she is stepping down.

**Release note**:
```release-note
NONE
```