### PR TITLE
Logcheck: Separate correct usage and migration tests

### DIFF
--- a/hack/tools/logcheck/main_test.go
+++ b/hack/tools/logcheck/main_test.go
@@ -23,5 +23,27 @@ import (
 )
 
 func TestAnalyzer(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), Analyzer)
+	tests := []struct {
+		name              string
+		allowUnstructured string
+		testPackage       string
+	}{
+		{
+			name:              "Allow unstructured logs",
+			allowUnstructured: "true",
+			testPackage:       "allowUnstructuredLogs",
+		},
+		{
+			name:              "Do not allow unstructured logs",
+			allowUnstructured: "false",
+			testPackage:       "doNotAllowUnstructuredLogs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analyzer := analyser()
+			analyzer.Flags.Set("allow-unstructured", tt.allowUnstructured)
+			analysistest.Run(t, analysistest.TestData(), analyzer, tt.testPackage)
+		})
+	}
 }

--- a/hack/tools/logcheck/testdata/src/allowUnstructuredLogs/allowUnstructuredLogs.go
+++ b/hack/tools/logcheck/testdata/src/allowUnstructuredLogs/allowUnstructuredLogs.go
@@ -14,35 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// test file for unstructured logging static check tool unit tests.
+// This fake package is created as golang.org/x/tools/go/analysis/analysistest
+// expects it to be here for loading. This package is used to test allow-unstructured
+// flag which suppresses errors when unstructured logging is used.
+// This is a test file for unstructured logging static check tool unit tests.
 
-package testdata
+package allowUnstructuredLogs
 
 import (
 	klog "k8s.io/klog/v2"
 )
 
-func printUnstructuredLog() {
-	klog.V(1).Infof("test log")      // want `unstructured logging function "Infof" should not be used`
-	klog.Infof("test log")           // want `unstructured logging function "Infof" should not be used`
-	klog.Info("test log")            // want `unstructured logging function "Info" should not be used`
-	klog.Infoln("test log")          // want `unstructured logging function "Infoln" should not be used`
-	klog.InfoDepth(1, "test log")    // want `unstructured logging function "InfoDepth" should not be used`
-	klog.Warning("test log")         // want `unstructured logging function "Warning" should not be used`
-	klog.Warningf("test log")        // want `unstructured logging function "Warningf" should not be used`
-	klog.WarningDepth(1, "test log") // want `unstructured logging function "WarningDepth" should not be used`
-	klog.Error("test log")           // want `unstructured logging function "Error" should not be used`
-	klog.Errorf("test log")          // want `unstructured logging function "Errorf" should not be used`
-	klog.Errorln("test log")         // want `unstructured logging function "Errorln" should not be used`
-	klog.ErrorDepth(1, "test log")   // want `unstructured logging function "ErrorDepth" should not be used`
-	klog.Fatal("test log")           // want `unstructured logging function "Fatal" should not be used`
-	klog.Fatalf("test log")          // want `unstructured logging function "Fatalf" should not be used`
-	klog.Fatalln("test log")         // want `unstructured logging function "Fatalln" should not be used`
-	klog.FatalDepth(1, "test log")   // want `unstructured logging function "FatalDepth" should not be used`
-
-}
-
-func printStructuredLog() {
+func allowUnstructuredLogs() {
+	// Structured logs
+	// Error is expected if structured logging pattern is not used correctly
 	klog.InfoS("test log")
 	klog.ErrorS(nil, "test log")
 	klog.InfoS("Starting container in a pod", "containerID", "containerID", "pod")                // want `Additional arguments to InfoS should always be Key Value pairs. Please check if there is any key or value missing.`
@@ -56,4 +41,23 @@ func printStructuredLog() {
 	klog.ErrorS(nil, "Starting container in a pod", testKey, "containerID") // want `Key positional arguments are expected to be inlined constant strings. `
 	klog.InfoS("test: %s", "testname")                                      // want `structured logging function "InfoS" should not use format specifier "%s"`
 	klog.ErrorS(nil, "test no.: %d", 1)                                     // want `structured logging function "ErrorS" should not use format specifier "%d"`
+
+	// Unstructured logs
+	// Error is not expected as this package allows unstructured logging
+	klog.V(1).Infof("test log")
+	klog.Infof("test log")
+	klog.Info("test log")
+	klog.Infoln("test log")
+	klog.InfoDepth(1, "test log")
+	klog.Warning("test log")
+	klog.Warningf("test log")
+	klog.WarningDepth(1, "test log")
+	klog.Error("test log")
+	klog.Errorf("test log")
+	klog.Errorln("test log")
+	klog.ErrorDepth(1, "test log")
+	klog.Fatal("test log")
+	klog.Fatalf("test log")
+	klog.Fatalln("test log")
+	klog.FatalDepth(1, "test log")
 }

--- a/hack/tools/logcheck/testdata/src/doNotAllowUnstructuredLogs/doNotAllowUnstructuredLogs.go
+++ b/hack/tools/logcheck/testdata/src/doNotAllowUnstructuredLogs/doNotAllowUnstructuredLogs.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This fake package is created as golang.org/x/tools/go/analysis/analysistest
+// expects it to be here for loading. This package is used to test default
+// behavior which is to report errors when unstructured logging is used.
+// This is a test file for unstructured logging static check tool unit tests.
+
+package doNotAllowUnstructuredLogs
+
+import (
+	klog "k8s.io/klog/v2"
+)
+
+func doNotAllowUnstructuredLogs() {
+	// Structured logs
+	// Error is expected if structured logging pattern is not used correctly
+	klog.InfoS("test log")
+	klog.ErrorS(nil, "test log")
+	klog.InfoS("Starting container in a pod", "containerID", "containerID", "pod")                // want `Additional arguments to InfoS should always be Key Value pairs. Please check if there is any key or value missing.`
+	klog.ErrorS(nil, "Starting container in a pod", "containerID", "containerID", "pod")          // want `Additional arguments to ErrorS should always be Key Value pairs. Please check if there is any key or value missing.`
+	klog.InfoS("Starting container in a pod", "测试", "containerID")                                // want `Key positional arguments "测试" are expected to be lowerCamelCase alphanumeric strings. Please remove any non-Latin characters.`
+	klog.ErrorS(nil, "Starting container in a pod", "测试", "containerID")                          // want `Key positional arguments "测试" are expected to be lowerCamelCase alphanumeric strings. Please remove any non-Latin characters.`
+	klog.InfoS("Starting container in a pod", 7, "containerID")                                   // want `Key positional arguments are expected to be inlined constant strings. Please replace 7 provided with string value`
+	klog.ErrorS(nil, "Starting container in a pod", 7, "containerID")                             // want `Key positional arguments are expected to be inlined constant strings. Please replace 7 provided with string value`
+	klog.InfoS("Starting container in a pod", map[string]string{"test1": "value"}, "containerID") // want `Key positional arguments are expected to be inlined constant strings. `
+	testKey := "a"
+	klog.ErrorS(nil, "Starting container in a pod", testKey, "containerID") // want `Key positional arguments are expected to be inlined constant strings. `
+	klog.InfoS("test: %s", "testname")                                      // want `structured logging function "InfoS" should not use format specifier "%s"`
+	klog.ErrorS(nil, "test no.: %d", 1)                                     // want `structured logging function "ErrorS" should not use format specifier "%d"`
+
+	// Unstructured logs
+	// Error is expected as this package does not allow unstructured logging
+	klog.V(1).Infof("test log")      // want `unstructured logging function "Infof" should not be used`
+	klog.Infof("test log")           // want `unstructured logging function "Infof" should not be used`
+	klog.Info("test log")            // want `unstructured logging function "Info" should not be used`
+	klog.Infoln("test log")          // want `unstructured logging function "Infoln" should not be used`
+	klog.InfoDepth(1, "test log")    // want `unstructured logging function "InfoDepth" should not be used`
+	klog.Warning("test log")         // want `unstructured logging function "Warning" should not be used`
+	klog.Warningf("test log")        // want `unstructured logging function "Warningf" should not be used`
+	klog.WarningDepth(1, "test log") // want `unstructured logging function "WarningDepth" should not be used`
+	klog.Error("test log")           // want `unstructured logging function "Error" should not be used`
+	klog.Errorf("test log")          // want `unstructured logging function "Errorf" should not be used`
+	klog.Errorln("test log")         // want `unstructured logging function "Errorln" should not be used`
+	klog.ErrorDepth(1, "test log")   // want `unstructured logging function "ErrorDepth" should not be used`
+	klog.Fatal("test log")           // want `unstructured logging function "Fatal" should not be used`
+	klog.Fatalf("test log")          // want `unstructured logging function "Fatalf" should not be used`
+	klog.Fatalln("test log")         // want `unstructured logging function "Fatalln" should not be used`
+	klog.FatalDepth(1, "test log")   // want `unstructured logging function "FatalDepth" should not be used`
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

logcheck: add flag for migration test 

`Migration test` is done by explicitly passing `-migration` flag to
logcheck. It runs correctness test but reports an error when
unstructured logging function is used in a migrated package.

`Correctness test` is run by default to check for correct usage
of structured logging patterns. It reports an error if structured
logging function is used incorrectly. It does not report an error
when structured logging function is not used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubernetes/issues/102439

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```