### PR TITLE
remove depend github.com/go-logr/logr， fix issue Logger changed from interface to struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module k8s.io/klog/v2
 
-go 1.13
+go 1.16
 
-require github.com/go-logr/logr v0.4.0
+require (
+	github.com/go-logr/logr v1.0.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module k8s.io/klog/v2
 
 go 1.16
-
-require (
-	github.com/go-logr/logr v1.0.0
-)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
-github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
+github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
-github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/klog.go
+++ b/klog.go
@@ -698,11 +698,11 @@ func (buf *buffer) someDigits(i, d int) int {
 	return copy(buf.tmp[i:], buf.tmp[j:])
 }
 
-func (l *loggingT) println(s severity, logr logr.Logger, filter LogFilter, args ...interface{}) {
+func (l *loggingT) println(s severity, loggr logr.Logger, filter LogFilter, args ...interface{}) {
 	buf, file, line := l.header(s, 0)
 	// if logr is set, we clear the generated header as we rely on the backing
 	// logr implementation to print headers
-	if logr != nil {
+	if loggr != nil {
 		l.putBuffer(buf)
 		buf = l.getBuffer()
 	}
@@ -710,18 +710,18 @@ func (l *loggingT) println(s severity, logr logr.Logger, filter LogFilter, args 
 		args = filter.Filter(args)
 	}
 	fmt.Fprintln(buf, args...)
-	l.output(s, logr, buf, 0 /* depth */, file, line, false)
+	l.output(s, loggr, buf, 0 /* depth */, file, line, false)
 }
 
-func (l *loggingT) print(s severity, logr logr.Logger, filter LogFilter, args ...interface{}) {
-	l.printDepth(s, logr, filter, 1, args...)
+func (l *loggingT) print(s severity, loggr logr.Logger, filter LogFilter, args ...interface{}) {
+	l.printDepth(s, loggr, filter, 1, args...)
 }
 
-func (l *loggingT) printDepth(s severity, logr logr.Logger, filter LogFilter, depth int, args ...interface{}) {
+func (l *loggingT) printDepth(s severity, loggr logr.Logger, filter LogFilter, depth int, args ...interface{}) {
 	buf, file, line := l.header(s, depth)
 	// if logr is set, we clear the generated header as we rely on the backing
 	// logr implementation to print headers
-	if logr != nil {
+	if loggr != nil {
 		l.putBuffer(buf)
 		buf = l.getBuffer()
 	}
@@ -732,14 +732,14 @@ func (l *loggingT) printDepth(s severity, logr logr.Logger, filter LogFilter, de
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
 	}
-	l.output(s, logr, buf, depth, file, line, false)
+	l.output(s, loggr, buf, depth, file, line, false)
 }
 
-func (l *loggingT) printf(s severity, logr logr.Logger, filter LogFilter, format string, args ...interface{}) {
+func (l *loggingT) printf(s severity, loggr logr.Logger, filter LogFilter, format string, args ...interface{}) {
 	buf, file, line := l.header(s, 0)
 	// if logr is set, we clear the generated header as we rely on the backing
 	// logr implementation to print headers
-	if logr != nil {
+	if loggr != nil {
 		l.putBuffer(buf)
 		buf = l.getBuffer()
 	}
@@ -750,17 +750,17 @@ func (l *loggingT) printf(s severity, logr logr.Logger, filter LogFilter, format
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
 	}
-	l.output(s, logr, buf, 0 /* depth */, file, line, false)
+	l.output(s, loggr, buf, 0 /* depth */, file, line, false)
 }
 
 // printWithFileLine behaves like print but uses the provided file and line number.  If
 // alsoLogToStderr is true, the log message always appears on standard error; it
 // will also appear in the log file unless --logtostderr is set.
-func (l *loggingT) printWithFileLine(s severity, logr logr.Logger, filter LogFilter, file string, line int, alsoToStderr bool, args ...interface{}) {
+func (l *loggingT) printWithFileLine(s severity, loggr logr.Logger, filter LogFilter, file string, line int, alsoToStderr bool, args ...interface{}) {
 	buf := l.formatHeader(s, file, line)
 	// if logr is set, we clear the generated header as we rely on the backing
 	// logr implementation to print headers
-	if logr != nil {
+	if loggr != nil {
 		l.putBuffer(buf)
 		buf = l.getBuffer()
 	}
@@ -771,7 +771,7 @@ func (l *loggingT) printWithFileLine(s severity, logr logr.Logger, filter LogFil
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
 	}
-	l.output(s, logr, buf, 2 /* depth */, file, line, alsoToStderr)
+	l.output(s, loggr, buf, 2 /* depth */, file, line, alsoToStderr)
 }
 
 // if loggr is specified, will call loggr.Error, otherwise output with logging module.

--- a/klog_test.go
+++ b/klog_test.go
@@ -33,8 +33,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/go-logr/logr"
 )
 
 // TODO: This test package should be refactored so that tests cannot
@@ -1655,10 +1653,10 @@ func (l *testLogr) Error(err error, msg string, keysAndValues ...interface{}) {
 	})
 }
 
-func (l *testLogr) Enabled() bool               { panic("not implemented") }
-func (l *testLogr) V(int) logr.Logger           { panic("not implemented") }
-func (l *testLogr) WithName(string) logr.Logger { panic("not implemented") }
-func (l *testLogr) WithValues(...interface{}) logr.Logger {
+func (l *testLogr) Enabled() bool          { panic("not implemented") }
+func (l *testLogr) V(int) Logger           { panic("not implemented") }
+func (l *testLogr) WithName(string) Logger { panic("not implemented") }
+func (l *testLogr) WithValues(...interface{}) Logger {
 	panic("not implemented")
 }
 
@@ -1673,7 +1671,7 @@ func (l *callDepthTestLogr) resetCallDepth() {
 	l.callDepth = 0
 }
 
-func (l *callDepthTestLogr) WithCallDepth(depth int) logr.Logger {
+func (l *callDepthTestLogr) WithCallDepth(depth int) Logger {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	// Note: Usually WithCallDepth would be implemented by cloning l

--- a/klogger.go
+++ b/klogger.go
@@ -1,6 +1,6 @@
 package klog
 
-// clone from github.com/go-logr/logr v0.4.0
+// copy from github.com/go-logr/logr v0.4.0
 type Logger interface {
 	// Enabled tests whether this Logger is enabled.  For example, commandline
 	// flags might be used to set the logging verbosity and disable some info

--- a/klogger.go
+++ b/klogger.go
@@ -1,0 +1,77 @@
+package klog
+
+// clone from github.com/go-logr/logr v0.4.0
+type Logger interface {
+	// Enabled tests whether this Logger is enabled.  For example, commandline
+	// flags might be used to set the logging verbosity and disable some info
+	// logs.
+	Enabled() bool
+
+	// Info logs a non-error message with the given key/value pairs as context.
+	//
+	// The msg argument should be used to add some constant description to
+	// the log line.  The key/value pairs can then be used to add additional
+	// variable information.  The key/value pairs should alternate string
+	// keys and arbitrary values.
+	Info(msg string, keysAndValues ...interface{})
+
+	// Error logs an error, with the given message and key/value pairs as context.
+	// It functions similarly to calling Info with the "error" named value, but may
+	// have unique behavior, and should be preferred for logging errors (see the
+	// package documentations for more information).
+	//
+	// The msg field should be used to add context to any underlying error,
+	// while the err field should be used to attach the actual error that
+	// triggered this log line, if present.
+	Error(err error, msg string, keysAndValues ...interface{})
+
+	// V returns an Logger value for a specific verbosity level, relative to
+	// this Logger.  In other words, V values are additive.  V higher verbosity
+	// level means a log message is less important.  It's illegal to pass a log
+	// level less than zero.
+	V(level int) Logger
+
+	// WithValues adds some key-value pairs of context to a logger.
+	// See Info for documentation on how key/value pairs work.
+	WithValues(keysAndValues ...interface{}) Logger
+
+	// WithName adds a new element to the logger's name.
+	// Successive calls with WithName continue to append
+	// suffixes to the logger's name.  It's strongly recommended
+	// that name segments contain only letters, digits, and hyphens
+	// (see the package documentation for more information).
+	WithName(name string) Logger
+}
+
+type CallDepthLogger interface {
+	Logger
+
+	// WithCallDepth returns a Logger that will offset the call stack by the
+	// specified number of frames when logging call site information.  If depth
+	// is 0 the attribution should be to the direct caller of this method.  If
+	// depth is 1 the attribution should skip 1 call frame, and so on.
+	// Successive calls to this are additive.
+	WithCallDepth(depth int) Logger
+}
+
+// WithCallDepth returns a Logger that will offset the call stack by the
+// specified number of frames when logging call site information, if possible.
+// This is useful for users who have helper functions between the "real" call
+// site and the actual calls to Logger methods.  If depth is 0 the attribution
+// should be to the direct caller of this function.  If depth is 1 the
+// attribution should skip 1 call frame, and so on.  Successive calls to this
+// are additive.
+//
+// If the underlying log implementation supports the CallDepthLogger interface,
+// the WithCallDepth method will be called and the result returned.  If the
+// implementation does not support CallDepthLogger, the original Logger will be
+// returned.
+//
+// Callers which care about whether this was supported or not should test for
+// CallDepthLogger support themselves.
+func WithCallDepth(logger Logger, depth int) Logger {
+	if decorator, ok := logger.(CallDepthLogger); ok {
+		return decorator.WithCallDepth(depth)
+	}
+	return logger
+}

--- a/klogr/calldepth-test/call_depth_helper_test.go
+++ b/klogr/calldepth-test/call_depth_helper_test.go
@@ -1,16 +1,16 @@
 package calldepth
 
 import (
-	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
 )
 
 // Putting these functions into a separate file makes it possible to validate that
 // their source code file is *not* logged because of WithCallDepth(1).
 
-func myInfo(l logr.Logger, msg string) {
-	logr.WithCallDepth(l, 1).Info(msg)
+func myInfo(l klog.Logger, msg string) {
+	klog.WithCallDepth(l, 1).Info(msg)
 }
 
-func myInfo2(l logr.Logger, msg string) {
-	myInfo(logr.WithCallDepth(l, 1), msg)
+func myInfo2(l klog.Logger, msg string) {
+	myInfo(klog.WithCallDepth(l, 1), msg)
 }

--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
 
@@ -40,14 +39,14 @@ func WithFormat(format Format) Option {
 
 // New returns a logr.Logger which serializes output itself
 // and writes it via klog.
-func New() logr.Logger {
+func New() klog.Logger {
 	return NewWithOptions(WithFormat(FormatSerialize))
 }
 
-// NewWithOptions returns a logr.Logger which serializes as determined
+// NewWithOptions returns a Logger which serializes as determined
 // by the WithFormat option and writes via klog. The default is
 // FormatKlog.
-func NewWithOptions(options ...Option) logr.Logger {
+func NewWithOptions(options ...Option) klog.Logger {
 	l := klogger{
 		level:  0,
 		prefix: "",
@@ -236,16 +235,16 @@ func (l klogger) Error(err error, msg string, kvList ...interface{}) {
 	}
 }
 
-func (l klogger) V(level int) logr.Logger {
+func (l klogger) V(level int) klog.Logger {
 	new := l.clone()
 	new.level = level
 	return new
 }
 
-// WithName returns a new logr.Logger with the specified name appended.  klogr
+// WithName returns a new klog.Logger with the specified name appended.  klogr
 // uses '/' characters to separate name elements.  Callers should not pass '/'
 // in the provided name string, but this library does not actually enforce that.
-func (l klogger) WithName(name string) logr.Logger {
+func (l klogger) WithName(name string) klog.Logger {
 	new := l.clone()
 	if len(l.prefix) > 0 {
 		new.prefix = l.prefix + "/"
@@ -254,17 +253,17 @@ func (l klogger) WithName(name string) logr.Logger {
 	return new
 }
 
-func (l klogger) WithValues(kvList ...interface{}) logr.Logger {
+func (l klogger) WithValues(kvList ...interface{}) klog.Logger {
 	new := l.clone()
 	new.values = append(new.values, kvList...)
 	return new
 }
 
-func (l klogger) WithCallDepth(depth int) logr.Logger {
+func (l klogger) WithCallDepth(depth int) klog.Logger {
 	new := l.clone()
 	new.callDepth += depth
 	return new
 }
 
-var _ logr.Logger = klogger{}
-var _ logr.CallDepthLogger = klogger{}
+var _ klog.Logger = klogger{}
+var _ klog.CallDepthLogger = klogger{}

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"k8s.io/klog/v2"
-
-	"github.com/go-logr/logr"
 )
 
 const (
@@ -19,7 +17,7 @@ const (
 )
 
 func testOutput(t *testing.T, format string) {
-	new := func() logr.Logger {
+	new := func() klog.Logger {
 		switch format {
 		case formatNew:
 			return New()
@@ -30,7 +28,7 @@ func testOutput(t *testing.T, format string) {
 		}
 	}
 	tests := map[string]struct {
-		klogr              logr.Logger
+		klogr              klog.Logger
 		text               string
 		keysAndValues      []interface{}
 		err                error
@@ -152,7 +150,7 @@ func testOutput(t *testing.T, format string) {
 			expectedKlogOutput: `"test" err="whoops"
 `,
 		},
-		"should correctly print regular error types when using logr.Error": {
+		"should correctly print regular error types when using klog.Error": {
 			klogr: new().V(0),
 			text:  "test",
 			err:   errors.New("whoops"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

Signed-off-by: ryouzhang ryouzhang@gmail.com

**What this PR does / why we need it**: 
remove depend on github.com/go-logr/logr fix issue Logger changed from interface to struct 
Copy github.com/go-logr/log Logger interface to klog

