### PR TITLE
bump go-logr to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module k8s.io/klog/v2
 
 go 1.13
 
-require github.com/go-logr/logr v0.4.0
+require github.com/go-logr/logr v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
-github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
+github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
I've found myself today wrestling with a go mod dependency nightmare, it seems that last version of glog has some breaking changes, so it is better to start to spot them sooner than later

```release-note
use go-logr v1.0.0
```