### PR TITLE
export ClearLogger

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -862,6 +862,9 @@ func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
 // Use as:
 //   ...
 //   klog.SetLogger(zapr.NewLogger(zapLog))
+//
+// To remove a backing logr implemention, use ClearLogger. Setting an
+// empty logger with SetLogger(logr.Logger{}) does not work.
 func SetLogger(logr logr.Logger) {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
@@ -869,7 +872,9 @@ func SetLogger(logr logr.Logger) {
 	logging.logr = &logr
 }
 
-func clearLogger() {
+// ClearLogger removes a backing logr implementation if one was set earlier
+// with SetLogger.
+func ClearLogger() {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
 

--- a/klog_test.go
+++ b/klog_test.go
@@ -1377,7 +1377,7 @@ func TestInfoSWithLogr(t *testing.T) {
 		t.Run(data.msg, func(t *testing.T) {
 			l := logr.New(logger)
 			SetLogger(l)
-			defer clearLogger()
+			defer ClearLogger()
 			defer logger.reset()
 
 			InfoS(data.msg, data.keysValues...)
@@ -1445,7 +1445,7 @@ func TestErrorSWithLogr(t *testing.T) {
 		t.Run(data.msg, func(t *testing.T) {
 			l := logr.New(logger)
 			SetLogger(l)
-			defer clearLogger()
+			defer ClearLogger()
 			defer logger.reset()
 
 			ErrorS(data.err, data.msg, data.keysValues...)
@@ -1503,7 +1503,7 @@ func TestCallDepthLogr(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			l := logr.New(logger)
 			SetLogger(l)
-			defer clearLogger()
+			defer ClearLogger()
 			defer logger.reset()
 			defer logger.resetCallDepth()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Code in Kubernetes also needs the ability to unset a logger.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ClearLogger can be used to remove a logger that was set previously with SetLogger.
```
