### PR TITLE
custom marshaler for ObjectRef

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module k8s.io/klog/v2
 
 go 1.13
 
-require github.com/go-logr/logr v1.0.0
+require github.com/go-logr/logr v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/go-logr/logr v1.0.0-rc1 h1:+ul9F74rBkPajeP8m4o3o0tiglmzNFsPnuhYyBCQ0Sc=
-github.com/go-logr/logr v1.0.0-rc1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
-github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/klog.go
+++ b/klog.go
@@ -1591,6 +1591,15 @@ func (ref ObjectRef) String() string {
 	return ref.Name
 }
 
+// MarshalLog ensures that loggers with support for structured output will log
+// as a struct by removing the String method via a custom type.
+func (ref ObjectRef) MarshalLog() interface{} {
+	type or ObjectRef
+	return or(ref)
+}
+
+var _ logr.Marshaler = ObjectRef{}
+
 // KMetadata is a subset of the kubernetes k8s.io/apimachinery/pkg/apis/meta/v1.Object interface
 // this interface may expand in the future, but will always be a subset of the
 // kubernetes k8s.io/apimachinery/pkg/apis/meta/v1.Object interface


### PR DESCRIPTION
**What this PR does / why we need it**:

This will be used by zapr for the JSON output format in Kubernetes. Without it,
the String method will be used, which is not as intended.

**Special notes for your reviewer**:

A test for this will be in https://github.com/kubernetes/kubernetes/pull/104877

**Release note**:
```release-note
KObj and the resulting ObjectRef will be logged as struct by loggers that support the logr.Marshaler interface.
```