### PR TITLE
structured logging: support log messages with line breaks

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -4,5 +4,7 @@ go 1.13
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	k8s.io/klog/v2 v2.0.0-20200324194303-db919253a3bc
+	k8s.io/klog/v2 v2.30.0
 )
+
+replace k8s.io/klog/v2 => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,7 @@
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 k8s.io/klog/v2 v2.0.0-20200324194303-db919253a3bc h1:E/enZ+SqXD3ChluFNvXqlLcUkqMQQDpiyGruRq5pjvY=

--- a/examples/structured_logging/structured_logging.go
+++ b/examples/structured_logging/structured_logging.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+
+	"k8s.io/klog/v2"
+)
+
+// MyStruct will be logged via %+v
+type MyStruct struct {
+	Name     string
+	Data     string
+	internal int
+}
+
+// MyStringer will be logged as string, with String providing that string.
+type MyString MyStruct
+
+func (m MyString) String() string {
+	return m.Name + ": " + m.Data
+}
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	someData := MyStruct{
+		Name: "hello",
+		Data: "world",
+	}
+
+	longData := MyStruct{
+		Name: "long",
+		Data: `Multiple
+lines
+with quite a bit
+of text.`,
+	}
+
+	logData := MyStruct{
+		Name: "log output from some program",
+		Data: `I0000 12:00:00.000000  123456 main.go:42] Starting
+E0000 12:00:01.000000  123456 main.go:43] Failed for some reason
+`,
+	}
+
+	stringData := MyString(longData)
+
+	klog.Infof("someData printed using InfoF: %v", someData)
+	klog.Infof("longData printed using InfoF: %v", longData)
+	klog.Infof(`stringData printed using InfoF,
+with the message across multiple lines:
+%v`, stringData)
+	klog.Infof("logData printed using InfoF:\n%v", logData)
+
+	klog.Info("=============================================")
+
+	klog.InfoS("using InfoS", "someData", someData)
+	klog.InfoS("using InfoS", "longData", longData)
+	klog.InfoS(`using InfoS with
+the message across multiple lines`,
+		"int", 1,
+		"stringData", stringData,
+		"str", "another value")
+	klog.InfoS("using InfoS", "logData", logData)
+	klog.InfoS("using InfoS", "boolean", true, "int", 1, "float", 0.1)
+
+	// The Kubernetes recommendation is to start the message with uppercase
+	// and not end with punctuation. See
+	// https://github.com/kubernetes/community/blob/HEAD/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
+	klog.InfoS("Did something", "item", "foobar")
+	// Not recommended, but also works.
+	klog.InfoS("This is a full sentence.", "item", "foobar")
+}

--- a/klog.go
+++ b/klog.go
@@ -808,8 +808,8 @@ func (l *loggingT) printS(err error, s severity, depth int, msg string, keysAndV
 	// Enhance readability by inserting : between message and key/value
 	// pairs, but only when the message does not already end with
 	// punctation.
-	if len(msg) > 0 && !unicode.IsPunct(rune(msg[len(msg)-1])) {
-		b.WriteString(":")
+	if len(msg) > 0 && !unicode.IsPunct(rune(msg[len(msg)-1])) && (err != nil || len(keysAndValues) > 0) {
+		b.WriteString(" |")
 	}
 	if err != nil {
 		kvListFormat(b, "err", err)
@@ -861,9 +861,9 @@ func writeStringValue(b *bytes.Buffer, k interface{}, quoteV bool, v string) {
 		return
 	}
 	// Complex multi-line string, show as-is with indention.
-	b.WriteString(fmt.Sprintf("===start of %s===\n ", k))
+	b.WriteString(fmt.Sprintf("%s>>>\n ", k))
 	writeString(b, v)
-	b.WriteString(fmt.Sprintf("\n ===end of %s===", k))
+	b.WriteString("\n <<<")
 }
 
 func writeString(b *bytes.Buffer, s string) {

--- a/klog_test.go
+++ b/klog_test.go
@@ -894,22 +894,22 @@ func TestInfoS(t *testing.T) {
 	}{
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: pod=\"kubedns\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test | pod=\"kubedns\"\n",
 			keysValues: []interface{}{"pod", "kubedns"},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: replicaNum=20\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test | replicaNum=20\n",
 			keysValues: []interface{}{"replicaNum", 20},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: err=\"test error\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test | err=\"test error\"\n",
 			keysValues: []interface{}{"err", errors.New("test error")},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: err=\"test error\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test | err=\"test error\"\n",
 			keysValues: []interface{}{"err", errors.New("test error")},
 		},
 	}
@@ -956,37 +956,37 @@ with a line break.`,
 	}{
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: pod=\"kubedns\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test | pod=\"kubedns\"\n",
 			keysValues: []interface{}{"pod", "kubedns"},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: replicaNum=20\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test | replicaNum=20\n",
 			keysValues: []interface{}{"replicaNum", 20},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: err=\"test error\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test | err=\"test error\"\n",
 			keysValues: []interface{}{"err", errors.New("test error")},
 		},
 		{
 			msg: `first message line
 second message line`,
 			format: `I0102 15:04:05.067890    1234 klog_test.go:%d] first message line
- second message line: ===start of multiLine===
+ second message line | multiLine>>>
  first value line
  second value line
- ===end of multiLine===
+ <<<
 `,
 			keysValues: []interface{}{"multiLine", `first value line
 second value line`},
 		},
 		{
 			msg: `message`,
-			format: `I0102 15:04:05.067890    1234 klog_test.go:%d] message: ===start of myData===
+			format: `I0102 15:04:05.067890    1234 klog_test.go:%d] message | myData>>>
  {Data:This is some long text
  with a line break.}
- ===end of myData===
+ <<<
 `,
 			keysValues: []interface{}{"myData", myData},
 		},
@@ -1041,11 +1041,11 @@ func TestErrorS(t *testing.T) {
 		}{
 			{
 				err:    fmt.Errorf("update status failed"),
-				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] Failed to update pod status: err=\"update status failed\" pod=\"kubedns\"\n",
+				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] Failed to update pod status | err=\"update status failed\" pod=\"kubedns\"\n",
 			},
 			{
 				err:    nil,
-				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] Failed to update pod status: pod=\"kubedns\"\n",
+				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] Failed to update pod status | pod=\"kubedns\"\n",
 			},
 		}
 		for _, e := range errorList {
@@ -1109,12 +1109,12 @@ func TestKvListFormat(t *testing.T) {
 No whitespace.`,
 				"pod", "kubedns",
 			},
-			want: ` ===start of multiLineString===
+			want: ` multiLineString>>>
  Hello world!
  	Starts with tab.
    Starts with spaces.
  No whitespace.
- ===end of multiLineString=== pod="kubedns"`,
+ <<< pod="kubedns"`,
 		},
 		{
 			keysValues: []interface{}{"pod", "kubedns", "maps", map[string]int{"three": 4}},

--- a/klog_test.go
+++ b/klog_test.go
@@ -894,22 +894,22 @@ func TestInfoS(t *testing.T) {
 	}{
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] \"test\" pod=\"kubedns\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: pod=\"kubedns\"\n",
 			keysValues: []interface{}{"pod", "kubedns"},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] \"test\" replicaNum=20\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: replicaNum=20\n",
 			keysValues: []interface{}{"replicaNum", 20},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] \"test\" err=\"test error\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: err=\"test error\"\n",
 			keysValues: []interface{}{"err", errors.New("test error")},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] \"test\" err=\"test error\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: err=\"test error\"\n",
 			keysValues: []interface{}{"err", errors.New("test error")},
 		},
 	}
@@ -943,6 +943,12 @@ func TestVInfoS(t *testing.T) {
 		return time.Date(2006, 1, 2, 15, 4, 5, .067890e9, time.Local)
 	}
 	pid = 1234
+	myData := struct {
+		Data string
+	}{
+		Data: `This is some long text
+with a line break.`,
+	}
 	var testDataInfo = []struct {
 		msg        string
 		format     string
@@ -950,18 +956,39 @@ func TestVInfoS(t *testing.T) {
 	}{
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] \"test\" pod=\"kubedns\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: pod=\"kubedns\"\n",
 			keysValues: []interface{}{"pod", "kubedns"},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] \"test\" replicaNum=20\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: replicaNum=20\n",
 			keysValues: []interface{}{"replicaNum", 20},
 		},
 		{
 			msg:        "test",
-			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] \"test\" err=\"test error\"\n",
+			format:     "I0102 15:04:05.067890    1234 klog_test.go:%d] test: err=\"test error\"\n",
 			keysValues: []interface{}{"err", errors.New("test error")},
+		},
+		{
+			msg: `first message line
+second message line`,
+			format: `I0102 15:04:05.067890    1234 klog_test.go:%d] first message line
+ second message line: ===start of multiLine===
+ first value line
+ second value line
+ ===end of multiLine===
+`,
+			keysValues: []interface{}{"multiLine", `first value line
+second value line`},
+		},
+		{
+			msg: `message`,
+			format: `I0102 15:04:05.067890    1234 klog_test.go:%d] message: ===start of myData===
+ {Data:This is some long text
+ with a line break.}
+ ===end of myData===
+`,
+			keysValues: []interface{}{"myData", myData},
 		},
 	}
 
@@ -987,7 +1014,7 @@ func TestVInfoS(t *testing.T) {
 				want = ""
 			}
 			if contents(infoLog) != want {
-				t.Errorf("V(%d).InfoS has unexpected output: \n got:\t%s\nwant:\t%s", l, contents(infoLog), want)
+				t.Errorf("V(%d).InfoS has unexpected output:\ngot:\n%s\nwant:\n%s\n", l, contents(infoLog), want)
 			}
 		}
 	}
@@ -1014,11 +1041,11 @@ func TestErrorS(t *testing.T) {
 		}{
 			{
 				err:    fmt.Errorf("update status failed"),
-				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] \"Failed to update pod status\" err=\"update status failed\" pod=\"kubedns\"\n",
+				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] Failed to update pod status: err=\"update status failed\" pod=\"kubedns\"\n",
 			},
 			{
 				err:    nil,
-				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] \"Failed to update pod status\" pod=\"kubedns\"\n",
+				format: "E0102 15:04:05.067890    1234 klog_test.go:%d] Failed to update pod status: pod=\"kubedns\"\n",
 			},
 		}
 		for _, e := range errorList {
@@ -1031,7 +1058,7 @@ func TestErrorS(t *testing.T) {
 			}
 			want := fmt.Sprintf(e.format, line)
 			if contents(errorLog) != want {
-				t.Errorf("ErrorS has wrong format: \n got:\t%s\nwant:\t%s", contents(errorLog), want)
+				t.Errorf("ErrorS has wrong format:\ngot:\n%s\nwant:\n%s\n", contents(errorLog), want)
 			}
 		}
 	}
@@ -1076,6 +1103,20 @@ func TestKvListFormat(t *testing.T) {
 			want:       " pod=\"kubedns\" bytes=\"\\ufffd\\ufffd=\\ufffd \\u2318\"",
 		},
 		{
+			keysValues: []interface{}{"multiLineString", `Hello world!
+	Starts with tab.
+  Starts with spaces.
+No whitespace.`,
+				"pod", "kubedns",
+			},
+			want: ` ===start of multiLineString===
+ Hello world!
+ 	Starts with tab.
+   Starts with spaces.
+ No whitespace.
+ ===end of multiLineString=== pod="kubedns"`,
+		},
+		{
 			keysValues: []interface{}{"pod", "kubedns", "maps", map[string]int{"three": 4}},
 			want:       " pod=\"kubedns\" maps=map[three:4]",
 		},
@@ -1113,7 +1154,7 @@ func TestKvListFormat(t *testing.T) {
 		b := &bytes.Buffer{}
 		kvListFormat(b, d.keysValues...)
 		if b.String() != d.want {
-			t.Errorf("kvlist format error:\n got:\n\t%s\nwant:\t%s", b.String(), d.want)
+			t.Errorf("kvlist format error:\ngot:\n%s\nwant:\n%s\n", b.String(), d.want)
 		}
 	}
 }

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -43,7 +43,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
-			expectedKlogOutput: `"test" akey="avalue"
+			expectedKlogOutput: `test: akey="avalue"
 `,
 		},
 		"should log with name and values passed to keysAndValues": {
@@ -52,7 +52,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: `me "msg"="test"  "akey"="avalue"
 `,
-			expectedKlogOutput: `"me: test" akey="avalue"
+			expectedKlogOutput: `me: test: akey="avalue"
 `,
 		},
 		"should log with multiple names and values passed to keysAndValues": {
@@ -61,7 +61,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: `hello/world "msg"="test"  "akey"="avalue"
 `,
-			expectedKlogOutput: `"hello/world: test" akey="avalue"
+			expectedKlogOutput: `hello/world: test: akey="avalue"
 `,
 		},
 		"should not print duplicate keys with the same value": {
@@ -70,7 +70,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
-			expectedKlogOutput: `"test" akey="avalue"
+			expectedKlogOutput: `test: akey="avalue"
 `,
 		},
 		"should only print the last duplicate key when the values are passed to Info": {
@@ -79,7 +79,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue2"
 `,
-			expectedKlogOutput: `"test" akey="avalue2"
+			expectedKlogOutput: `test: akey="avalue2"
 `,
 		},
 		"should only print the duplicate key that is passed to Info if one was passed to the logger": {
@@ -88,7 +88,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue"
 `,
-			expectedKlogOutput: `"test" akey="avalue"
+			expectedKlogOutput: `test: akey="avalue"
 `,
 		},
 		"should sort within logger and parameter key/value pairs in the default format and dump the logger pairs first": {
@@ -97,7 +97,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey5", "avalue5", "akey4", "avalue4"},
 			expectedOutput: ` "msg"="test" "akey1"="avalue1" "akey8"="avalue8" "akey9"="avalue9" "akey4"="avalue4" "akey5"="avalue5"
 `,
-			expectedKlogOutput: `"test" akey9="avalue9" akey8="avalue8" akey1="avalue1" akey5="avalue5" akey4="avalue4"
+			expectedKlogOutput: `test: akey9="avalue9" akey8="avalue8" akey1="avalue1" akey5="avalue5" akey4="avalue4"
 `,
 		},
 		"should only print the key passed to Info when one is already set on the logger": {
@@ -106,7 +106,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue2"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue2"
 `,
-			expectedKlogOutput: `"test" akey="avalue2"
+			expectedKlogOutput: `test: akey="avalue2"
 `,
 		},
 		"should correctly handle odd-numbers of KVs": {
@@ -115,7 +115,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
 			expectedOutput: ` "msg"="test"  "akey"="avalue" "akey2"=null
 `,
-			expectedKlogOutput: `"test" akey="avalue" akey2=<nil>
+			expectedKlogOutput: `test: akey="avalue" akey2=<nil>
 `,
 		},
 		"should correctly html characters": {
@@ -124,7 +124,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "<&>"},
 			expectedOutput: ` "msg"="test"  "akey"="<&>"
 `,
-			expectedKlogOutput: `"test" akey="<&>"
+			expectedKlogOutput: `test: akey="<&>"
 `,
 		},
 		"should correctly handle odd-numbers of KVs in both log values and Info args": {
@@ -133,7 +133,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
 			expectedOutput: ` "msg"="test" "basekey1"="basevar1" "basekey2"=null "akey"="avalue" "akey2"=null
 `,
-			expectedKlogOutput: `"test" basekey1="basevar1" basekey2=<nil> akey="avalue" akey2=<nil>
+			expectedKlogOutput: `test: basekey1="basevar1" basekey2=<nil> akey="avalue" akey2=<nil>
 `,
 		},
 		"should correctly print regular error types": {
@@ -142,7 +142,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"err", errors.New("whoops")},
 			expectedOutput: ` "msg"="test"  "err"="whoops"
 `,
-			expectedKlogOutput: `"test" err="whoops"
+			expectedKlogOutput: `test: err="whoops"
 `,
 		},
 		"should use MarshalJSON in the default format if an error type implements it": {
@@ -151,7 +151,7 @@ func testOutput(t *testing.T, format string) {
 			keysAndValues: []interface{}{"err", &customErrorJSON{"whoops"}},
 			expectedOutput: ` "msg"="test"  "err"="WHOOPS"
 `,
-			expectedKlogOutput: `"test" err="whoops"
+			expectedKlogOutput: `test: err="whoops"
 `,
 		},
 		"should correctly print regular error types when using logr.Error": {
@@ -163,9 +163,9 @@ func testOutput(t *testing.T, format string) {
  "msg"="test" "error"="whoops"  
  "msg"="test" "error"="whoops"  
 `,
-			expectedKlogOutput: `"test" err="whoops"
-"test" err="whoops"
-"test" err="whoops"
+			expectedKlogOutput: `test: err="whoops"
+test: err="whoops"
+test: err="whoops"
 `,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The initial structured logging output (almost) always produced a single line
per log message, with quoting of strings to represent line breaks as \n.  This
made the output hard to read (see
https://github.com/kubernetes/kubernetes/issues/104868).

It was still possible to get line breaks when formatting a value with `%+v` and
that ended up emitting line breaks; this was probably not intended.

Now the message is never quoted, as in non-structured output. String values are
quoted if they contain no line break. If they do, start/end markers delimit the
text which appears on its own lines.

All additional lines of a structure log message get indented by one space. This
makes it obvious where a new log message starts, which is an improvement
compared to the traditional format.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/106262, https://github.com/kubernetes/kubernetes/issues/106428

**Special notes for your reviewer**:

Traditional output:
```
I1112 14:06:35.783354  328441 structured_logging.go:42] someData printed using InfoF: {hello world 0}
I1112 14:06:35.783472  328441 structured_logging.go:43] longData printed using InfoF: {long Multiple
lines
with quite a bit
of text. 0}
I1112 14:06:35.783483  328441 structured_logging.go:44] stringData printed using InfoF,
with the message across multiple lines:
long: Multiple
lines
with quite a bit
of text.
I1112 14:06:35.898176  142908 structured_logging.go:54] logData printed using InfoF:
{log output from some program I0000 12:00:00.000000  123456 main.go:42] Starting
E0000 12:00:01.000000  123456 main.go:43] Failed for some reason
 0}
```

Old InfoS output before this commit:
```
I1112 14:06:35.783512  328441 structured_logging.go:50] "using InfoS" someData={Name:hello Data:world internal:0}
I1112 14:06:35.783529  328441 structured_logging.go:51] "using InfoS" longData={Name:long Data:Multiple
lines
with quite a bit
of text. internal:0}
I1112 14:06:35.783549  328441 structured_logging.go:52] "using InfoS with\nthe message across multiple lines" nt=1 stringData="long: Multiple\nlines\nwith quite a bit\nof text." str="another value"
I1112 14:06:35.898278  142908 structured_logging.go:65] "using InfoS" logData={Name:log output from some program Data:I0000 12:00:00.000000  123456 main.go:42] Starting
E0000 12:00:01.000000  123456 main.go:43] Failed for some reason
 internal:0}
I1112 14:06:35.783565  328441 structured_logging.go:61] "Did something" item="foobar"
I1112 14:06:35.783576  328441 structured_logging.go:63] "This is a full sentence." item="foobar"
```

New InfoS output:
```
I1119 13:18:00.210970   78836 structured_logging.go:58] using InfoS | someData={Name:hello Data:world internal:0}
I1119 13:18:00.210988   78836 structured_logging.go:59] using InfoS | longData>>>
 {Name:long Data:Multiple
 lines
 with quite a bit
 of text. internal:0}
 <<<
I1119 13:18:00.211009   78836 structured_logging.go:60] using InfoS with
 the message across multiple lines | int=1 stringData>>>
 long: Multiple
 lines
 with quite a bit
 of text.
 <<< str="another value"
I1119 13:18:00.211032   78836 structured_logging.go:65] using InfoS | logData>>>
 {Name:log output from some program Data:I0000 12:00:00.000000  123456 main.go:42] Starting
 E0000 12:00:01.000000  123456 main.go:43] Failed for some reason
  internal:0}
 <<<
I1119 13:18:00.211068   78836 structured_logging.go:71] Did something | item="foobar"
I1119 13:18:00.211079   78836 structured_logging.go:73] This is a full sentence. item="foobar"
```

**Release note**:
```release-note
In structured output (= InfoS, ErrorS), values with line breaks will be printed across multiple lines to make the output more readable. The message is also not quoted anymore and may stretch across multiple lines. Every new line gets indented by one space.
```
