### PR TITLE
add structured logging helper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,16 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Test
+    - name: Test klog
       run: |
         go get -t -v ./...
         go test -v -race ./...
+    - name: Test tools
+      run: |
         cd hack/tools && go test -v -race ./...
+    - name: Test examples
+      run: |
+        cd examples && go test -v -race ./...
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -4,5 +4,7 @@ go 1.13
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	k8s.io/klog/v2 v2.0.0-20200324194303-db919253a3bc
+	k8s.io/klog/v2 v2.30.0
 )
+
+replace k8s.io/klog/v2 => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,7 @@
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 k8s.io/klog/v2 v2.0.0-20200324194303-db919253a3bc h1:E/enZ+SqXD3ChluFNvXqlLcUkqMQQDpiyGruRq5pjvY=

--- a/examples/klog_as/klog_as_test.go
+++ b/examples/klog_as/klog_as_test.go
@@ -69,6 +69,6 @@ func ExampleAs() {
 	// "No formatting" item={some:thing data:someone}
 	// "With stringer" item="{Some: \"thing\" Data: \"someone\"}"
 	// "With marshaler" item={Data:someone Some:thing}
-	// "Callbacks should never be nil" item=<nil>
+	// "Callbacks should never be nil" item="<application error, nil text callback>"
 	// "hello" obj="world"
 }

--- a/examples/klog_as/klog_as_test.go
+++ b/examples/klog_as/klog_as_test.go
@@ -1,0 +1,69 @@
+// Copyright 2021 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package klog_test
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"k8s.io/klog/v2"
+)
+
+type myStruct struct {
+	some, data string
+}
+
+func ExampleAs() {
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "false")
+	flag.Set("alsologtostderr", "false")
+	flag.Set("skip_headers", "true")
+	klog.SetOutput(os.Stdout)
+
+	item := myStruct{
+		some: "thing",
+		data: "someone",
+	}
+	klog.InfoS("No formatting", "item", item)
+
+	as := klog.As{
+		Text: func() string {
+			return fmt.Sprintf("{Some: %q Data: %q}", item.some, item.data)
+		},
+		Object: func() interface{} {
+			return struct {
+				Data, Some string
+			}{
+				Some: item.some,
+				Data: item.data,
+			}
+		},
+	}
+	klog.InfoS("With stringer", "item", as)
+
+	// We don't have a logger in klog which uses MarshalLog, but we can
+	// test its behavior by invoking it directly.
+	klog.InfoS("With marshaler", "item", as.MarshalLog())
+
+	// Not a valid call, but klog.As tolerates it.
+	klog.InfoS("Callbacks should never be nil", "item", klog.As{})
+
+	// Output:
+	// "No formatting" item={some:thing data:someone}
+	// "With stringer" item="{Some: \"thing\" Data: \"someone\"}"
+	// "With marshaler" item={Data:someone Some:thing}
+	// "Callbacks should never be nil" item="<<unknown, nil Text function>>"
+}

--- a/examples/structured_logging/structured_logging.go
+++ b/examples/structured_logging/structured_logging.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+
+	"k8s.io/klog/v2"
+)
+
+// MyStruct will be logged via %+v
+type MyStruct struct {
+	Name     string
+	Data     string
+	internal int
+}
+
+// MyStringer will be logged as string, with String providing that string.
+type MyString MyStruct
+
+func (m MyString) String() string {
+	return m.Name + ": " + m.Data
+}
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	someData := MyStruct{
+		Name: "hello",
+		Data: "world",
+	}
+
+	longData := MyStruct{
+		Name: "long",
+		Data: `Multiple
+lines
+with quite a bit
+of text.`,
+	}
+
+	logData := MyStruct{
+		Name: "log output from some program",
+		Data: `I0000 12:00:00.000000  123456 main.go:42] Starting
+E0000 12:00:01.000000  123456 main.go:43] Failed for some reason
+`,
+	}
+
+	stringData := MyString(longData)
+
+	klog.Infof("someData printed using InfoF: %v", someData)
+	klog.Infof("longData printed using InfoF: %v", longData)
+	klog.Infof(`stringData printed using InfoF,
+with the message across multiple lines:
+%v`, stringData)
+	klog.Infof("logData printed using InfoF:\n%v", logData)
+
+	klog.Info("=============================================")
+
+	klog.InfoS("using InfoS", "someData", someData)
+	klog.InfoS("using InfoS", "longData", longData)
+	klog.InfoS(`using InfoS with
+the message across multiple lines`,
+		"int", 1,
+		"stringData", stringData,
+		"str", "another value")
+	klog.InfoS("using InfoS", "logData", logData)
+	klog.InfoS("using InfoS", "boolean", true, "int", 1, "float", 0.1)
+
+	// The Kubernetes recommendation is to start the message with uppercase
+	// and not end with punctuation. See
+	// https://github.com/kubernetes/community/blob/HEAD/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
+	klog.InfoS("Did something", "item", "foobar")
+	// Not recommended, but also works.
+	klog.InfoS("This is a full sentence.", "item", "foobar")
+}

--- a/klog.go
+++ b/klog.go
@@ -1387,6 +1387,14 @@ func InfoSDepth(depth int, msg string, keysAndValues ...interface{}) {
 	logging.infoS(logging.logr, logging.filter, depth, msg, keysAndValues...)
 }
 
+// InfoSDepth is equivalent to the global InfoSDepth function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) InfoSDepth(depth int, msg string, keysAndValues ...interface{}) {
+	if v.enabled {
+		logging.infoS(v.logr, v.filter, depth, msg, keysAndValues...)
+	}
+}
+
 // Deprecated: Use ErrorS instead.
 func (v Verbose) Error(err error, msg string, args ...interface{}) {
 	if v.enabled {

--- a/klog.go
+++ b/klog.go
@@ -1647,3 +1647,33 @@ func KObjs(arg interface{}) []ObjectRef {
 	}
 	return objectRefs
 }
+
+// As implements both the fmt.Stringer and logr.Marshal interface with some
+// custom functions. Plain text output then will include the result of the Text
+// function whereas structured output (such as JSON) will include the result of
+// the Object function.
+//
+// The same can be done with custom structs. The advantage of this helper is
+// that the formatting code can be written inline in the same function that
+// logs some object.
+type As struct {
+	Text   func() string
+	Object func() interface{}
+}
+
+func (a As) String() string {
+	if a.Text == nil {
+		return "<<unknown, nil Text function>>"
+	}
+	return a.Text()
+}
+
+func (a As) MarshalLog() interface{} {
+	if a.Object == nil {
+		return "<<unknown, nil Object function>>"
+	}
+	return a.Object()
+}
+
+var _ fmt.Stringer = As{}
+var _ logr.Marshaler = As{}


### PR DESCRIPTION
**What this PR does / why we need it**:

When passing an object with complex content as a key in a key/value list, good
formatting of that object will be different for text and structured
output. Custom formatters can be provided by implementing fmt.Stringer and
logr.Marshaler, but that implies defining custom types outside of the function
which does the logging.

The new LogAs helper struct provideds the necessary boilerplate code and allows
users to keep all code inside the same function.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/106258

**Release note**:
```release-note
The klog.As helper struct can be used to log values as text in the klog text output and as real structure in loggers which produce structured output (for example, JSON).
```