### PR TITLE
Using OS targeted go files to separate out the username logic.

### DIFF
--- a/klog_file.go
+++ b/klog_file.go
@@ -22,9 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -55,38 +53,6 @@ func init() {
 	if h, err := os.Hostname(); err == nil {
 		host = shortHostname(h)
 	}
-}
-
-func getUserName() string {
-	userNameOnce.Do(func() {
-		// On Windows, the Go 'user' package requires netapi32.dll.
-		// This affects Windows Nano Server:
-		//   https://github.com/golang/go/issues/21867
-		// Fallback to using environment variables.
-		if runtime.GOOS == "windows" {
-			u := os.Getenv("USERNAME")
-			if len(u) == 0 {
-				return
-			}
-			// Sanitize the USERNAME since it may contain filepath separators.
-			u = strings.Replace(u, `\`, "_", -1)
-
-			// user.Current().Username normally produces something like 'USERDOMAIN\USERNAME'
-			d := os.Getenv("USERDOMAIN")
-			if len(d) != 0 {
-				userName = d + "_" + u
-			} else {
-				userName = u
-			}
-		} else {
-			current, err := user.Current()
-			if err == nil {
-				userName = current.Username
-			}
-		}
-	})
-
-	return userName
 }
 
 // shortHostname returns its argument, truncating at the first period.

--- a/klog_file_others.go
+++ b/klog_file_others.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package klog
+
+import (
+	"os/user"
+)
+
+func getUserName() string {
+	userNameOnce.Do(func() {
+		current, err := user.Current()
+		if err == nil {
+			userName = current.Username
+		}
+	})
+
+	return userName
+}

--- a/klog_file_windows.go
+++ b/klog_file_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+// +build windows
+
+package klog
+
+import (
+	"os"
+	"strings"
+)
+
+func getUserName() string {
+	userNameOnce.Do(func() {
+		// On Windows, the Go 'user' package requires netapi32.dll.
+		// This affects Windows Nano Server:
+		//   https://github.com/golang/go/issues/21867
+		// Fallback to using environment variables.
+		u := os.Getenv("USERNAME")
+		if len(u) == 0 {
+			return
+		}
+		// Sanitize the USERNAME since it may contain filepath separators.
+		u = strings.Replace(u, `\`, "_", -1)
+
+		// user.Current().Username normally produces something like 'USERDOMAIN\USERNAME'
+		d := os.Getenv("USERDOMAIN")
+		if len(d) != 0 {
+			userName = d + "_" + u
+		} else {
+			userName = u
+		}
+	})
+
+	return userName
+}


### PR DESCRIPTION
We have discovered that in some instances the runtime.GOOS="windows" check is failing on nanoserver when doing cross compilation. It appears to be inconsistent. Moving this into it's own OS targeted go file prevents it from being an issue.

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR removes the if runtime check in klog_file.go and moves the decision to compilation time. We have disovered that in some instances the if runtime check is failing on nanoserver and the code was dropping down into the else statement causing the net32api error that is in the comment for that code to be triggered.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```