### PR TITLE
add format test for KObjs

### DIFF
--- a/klog_test.go
+++ b/klog_test.go
@@ -1107,6 +1107,18 @@ func TestKvListFormat(t *testing.T) {
 			keysValues: []interface{}{"pod", KObj((*kMetadataMock)(nil)), "status", "ready"},
 			want:       " pod=\"\" status=\"ready\"",
 		},
+		{
+			keysValues: []interface{}{"pods", KObjs([]kMetadataMock{
+				{
+					name: "kube-dns",
+					ns:   "kube-system",
+				},
+				{
+					name: "mi-conf",
+				},
+			})},
+			want: " pods=[kube-system/kube-dns mi-conf]",
+		},
 	}
 
 	for _, d := range testKVList {


### PR DESCRIPTION
**What this PR does / why we need it**:

This wasn't covered before. At first glance the different formatting of the
individual objects (no quotation marks) looks a bit odd compared to how KObj is
formatted, but that's what we have right now.

**Release note**:
```release-note
NONE
```
