### PR TITLE
add Verbose.InfoSDepth

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -1387,6 +1387,14 @@ func InfoSDepth(depth int, msg string, keysAndValues ...interface{}) {
 	logging.infoS(logging.logr, logging.filter, depth, msg, keysAndValues...)
 }
 
+// InfoSDepth is equivalent to the global InfoSDepth function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) InfoSDepth(depth int, msg string, keysAndValues ...interface{}) {
+	if v.enabled {
+		logging.infoS(v.logr, v.filter, depth, msg, keysAndValues...)
+	}
+}
+
 // Deprecated: Use ErrorS instead.
 func (v Verbose) Error(err error, msg string, args ...interface{}) {
 	if v.enabled {


### PR DESCRIPTION
**What this PR does / why we need it**:

It is needed in Kubernetes for code like this (from
`k8s.io/apiserver/pkg/server/httplog/httplog.go`):

```
  // Log is intended to be called once at the end of your request handler, via defer
  func (rl *respLogger) Log() {
          ...

          klog.V(withLoggingLevel).InfoSDepth(1, "HTTP", keysAndValues...)
  }
```

Without `InfoSDepth` as method for `Verbose`, such code has to use `klog.InfoSDepth`,
which records the message with v=0 in JSON output. This is the wrong verbosity
for this debug message.

We don't need `Verbose.ErrorSDepth` (error messages have no verbosity) and also
no `Verbose.Info[f]Depth` (when touching code, it should be rewritten to use
`Verbose.InfoSDepth` instead)

**Release note**:

```release-note
added Verbose.InfoS
```
