### PR TITLE
Recover from nil pointers when logging

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -847,7 +847,7 @@ func kvListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
 		// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
 		switch v := v.(type) {
 		case fmt.Stringer:
-			writeStringValue(b, true, v.String())
+			writeStringValue(b, true, stringerToString(v))
 		case string:
 			writeStringValue(b, true, v)
 		case error:
@@ -870,6 +870,16 @@ func kvListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
 			writeStringValue(b, false, fmt.Sprintf("%+v", v))
 		}
 	}
+}
+
+func stringerToString(s fmt.Stringer) (ret string) {
+	defer func() {
+		if err := recover(); err != nil {
+			ret = "nil"
+		}
+	}()
+	ret = s.String()
+	return
 }
 
 func writeStringValue(b *bytes.Buffer, quote bool, v string) {

--- a/klog_test.go
+++ b/klog_test.go
@@ -1063,8 +1063,20 @@ func TestErrorS(t *testing.T) {
 	}
 }
 
+// point conforms to fmt.Stringer interface as it implements the String() method
+type point struct {
+	x int
+	y int
+}
+
+// we now have a value receiver
+func (p point) String() string {
+	return fmt.Sprintf("x=%d, y=%d", p.x, p.y)
+}
+
 // Test that kvListFormat works as advertised.
 func TestKvListFormat(t *testing.T) {
+	var emptyPoint *point
 	var testKVList = []struct {
 		keysValues []interface{}
 		want       string
@@ -1158,6 +1170,10 @@ No whitespace.`,
 				},
 			})},
 			want: " pods=[kube-system/kube-dns mi-conf]",
+		},
+		{
+			keysValues: []interface{}{"point-1", point{100, 200}, "point-2", emptyPoint},
+			want:       " point-1=\"x=100, y=200\" point-2=\"nil\"",
 		},
 	}
 


### PR DESCRIPTION
we used to rely on `fmt.Sprintf` which was handling the nil pointers for us. With the latest changes we avoid using `fmt.Sprintf` for speed/performance, So let's use a `recover` to survive the `panic`.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #278

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes a problem handling nil pointers when logging
```