### PR TITLE
Panic on empty info with custom logr

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -729,7 +729,7 @@ func (l *loggingT) printDepth(s severity, logger *logr.Logger, filter LogFilter,
 		args = filter.Filter(args)
 	}
 	fmt.Fprint(buf, args...)
-	if buf.Bytes()[buf.Len()-1] != '\n' {
+	if buf.Len() == 0 || buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
 	}
 	l.output(s, logger, buf, depth, file, line, false)

--- a/klog_test.go
+++ b/klog_test.go
@@ -1416,6 +1416,42 @@ func TestLogFilter(t *testing.T) {
 	}
 }
 
+func TestInfoWithLogr(t *testing.T) {
+	logger := new(testLogr)
+
+	testDataInfo := []struct {
+		msg      string
+		expected testLogrEntry
+	}{{
+		msg: "foo",
+		expected: testLogrEntry{
+			severity: infoLog,
+			msg:      "foo\n",
+		},
+	}, {
+		msg: "",
+		expected: testLogrEntry{
+			severity: infoLog,
+			msg:      "\n",
+		},
+	}}
+
+	for _, data := range testDataInfo {
+		t.Run(data.msg, func(t *testing.T) {
+			l := logr.New(logger)
+			SetLogger(l)
+			defer ClearLogger()
+			defer logger.reset()
+
+			Info(data.msg)
+
+			if !reflect.DeepEqual(logger.entries, []testLogrEntry{data.expected}) {
+				t.Errorf("expected: %+v; but got: %+v", []testLogrEntry{data.expected}, logger.entries)
+			}
+		})
+	}
+}
+
 func TestInfoSWithLogr(t *testing.T) {
 	logger := new(testLogr)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent panic on logging empty string.

**Release note**:
```release-note
1. Prevent panic when using info or error with custom logger.
```