### PR TITLE
SetLogger/ClearLogger/SetLogFilter cleanup

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -965,15 +965,18 @@ func (rb *redirectBuffer) Write(bytes []byte) (n int, err error) {
 //
 // To remove a backing logr implemention, use ClearLogger. Setting an
 // empty logger with SetLogger(logr.Logger{}) does not work.
+//
+// Modifying the logger is not thread-safe and should be done while no other
+// goroutines invoke log calls, usually during program initialization.
 func SetLogger(logr logr.Logger) {
-	logging.mu.Lock()
-	defer logging.mu.Unlock()
-
 	logging.logr = &logr
 }
 
 // ClearLogger removes a backing logr implementation if one was set earlier
 // with SetLogger.
+//
+// Modifying the logger is not thread-safe and should be done while no other
+// goroutines invoke log calls, usually during program initialization.
 func ClearLogger() {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
@@ -1775,10 +1778,11 @@ type LogFilter interface {
 	FilterS(msg string, keysAndValues []interface{}) (string, []interface{})
 }
 
+// SetLogFilter installs a filter that is used for all log calls.
+//
+// Modifying the filter is not thread-safe and should be done while no other
+// goroutines invoke log calls, usually during program initialization.
 func SetLogFilter(filter LogFilter) {
-	logging.mu.Lock()
-	defer logging.mu.Unlock()
-
 	logging.filter = filter
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The implementation might have given the wrong impression that filter and logger can be changed at runtime. They are *not* thread-safe, so let's document that.

Adding the filter in https://github.com/kubernetes/klog/pull/183 also added it to Verbose, which made the performance-critical V() slower. This gets simplified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes/klog/issues/285

**Special notes for your reviewer**:

The second commit is not strictly related and could be left out.

**Release note**:
```release-note
Beware that SetLogger/ClearLogger/SetLogFilter are not and never have been thread-safe. They should be called in serial sections of a program (initialization, non-parallel tests).
```