### PR TITLE
contextual logging

### DIFF
--- a/contextual.go
+++ b/contextual.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+// This file provides the implementation of
+// https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1602-structured-logging
+//
+// SetLogger and ClearLogger were originally added to klog.go and got moved
+// here. Contextual logging adds a way to retrieve a Logger for direct logging
+// without the logging calls in klog.go.
+//
+// The global variables are expected to be modified only during sequential
+// parts of a program (init, serial tests) and therefore are not protected by
+// mutex locking.
+
+var (
+	// contextualLoggingEnabled controls whether contextual logging is
+	// active. Disabling it may have some small performance benefit.
+	contextualLoggingEnabled = true
+
+	// globalLogger is the global Logger chosen by users of klog, nil if
+	// none is available.
+	globalLogger *Logger
+
+	// contextualLogger defines whether globalLogger may get called
+	// directly.
+	contextualLogger bool
+
+	// klogLogger is used as fallback for logging through the normal klog code
+	// when no Logger is set.
+	klogLogger logr.Logger = logr.New(&klogger{})
+)
+
+// SetLogger sets a Logger implementation that will be used as backing
+// implementation of the traditional klog log calls. klog will do its own
+// verbosity checks before calling logger.V().Info. logger.Error is always
+// called, regardless of the klog verbosity settings.
+//
+// If set, all log lines will be suppressed from the regular output, and
+// redirected to the logr implementation.
+// Use as:
+//   ...
+//   klog.SetLogger(zapr.NewLogger(zapLog))
+//
+// To remove a backing logr implemention, use ClearLogger. Setting an
+// empty logger with SetLogger(logr.Logger{}) does not work.
+//
+// Modifying the logger is not thread-safe and should be done while no other
+// goroutines invoke log calls, usually during program initialization.
+func SetLogger(logger logr.Logger) {
+	SetLoggerWithOptions(logger)
+}
+
+// SetLoggerWithOptions is a more flexible version of SetLogger. Without
+// additional options, it behaves exactly like SetLogger. By passing
+// ContextualLogger(true) as option, it can be used to set a logger that then
+// will also get called directly by applications which retrieve it via
+// FromContext, Background, or TODO.
+//
+// Supporting direct calls is recommended because it avoids the overhead of
+// routing log entries through klogr into klog and then into the actual Logger
+// backend.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func SetLoggerWithOptions(logger logr.Logger, opts ...LoggerOption) {
+	globalLogger = &logger
+	var o loggerOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	contextualLogger = o.contextualLogger
+}
+
+// ContextualLogger determines whether the logger passed to
+// SetLoggerWithOptions may also get called directly. Such a logger cannot rely
+// on verbosity checking in klog.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func ContextualLogger(enabled bool) LoggerOption {
+	return func(o *loggerOptions) {
+		o.contextualLogger = enabled
+	}
+}
+
+// LoggerOption implements the functional parameter paradigm for
+// SetLoggerWithOptions.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type LoggerOption func(o *loggerOptions)
+
+type loggerOptions struct {
+	contextualLogger bool
+}
+
+// SetContextualLogger does the same as SetLogger, but in addition the
+// logger may also get called directly by code that retrieves it
+// with FromContext, TODO or Background. The logger therefore must
+// implements its own verbosity checking.
+func SetContextualLogger(logger logr.Logger) {
+	globalLogger = &logger
+	contextualLogger = true
+}
+
+// ClearLogger removes a backing Logger implementation if one was set earlier
+// with SetLogger.
+//
+// Modifying the logger is not thread-safe and should be done while no other
+// goroutines invoke log calls, usually during program initialization.
+func ClearLogger() {
+	globalLogger = nil
+}
+
+// EnableContextualLogging controls whether contextual logging is enabled.
+// By default it is enabled. When disabled, FromContext avoids looking up
+// the logger in the context and always returns the global logger.
+// LoggerWithValues, LoggerWithName, and NewContext become no-ops
+// and return their input logger respectively context. This may be useful
+// to avoid the additional overhead for contextual logging.
+//
+// This must be called during initialization before goroutines are started.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func EnableContextualLogging(enabled bool) {
+	contextualLoggingEnabled = enabled
+}
+
+// FromContext retrieves a logger set by the caller or, if not set,
+// falls back to the program's global logger (a Logger instance or klog
+// itself).
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func FromContext(ctx context.Context) Logger {
+	if contextualLoggingEnabled {
+		if logger, err := logr.FromContext(ctx); err == nil {
+			return logger
+		}
+	}
+
+	return Background()
+}
+
+// TODO can be used as a last resort by code that has no means of
+// receiving a logger from its caller. FromContext or an explicit logger
+// parameter should be used instead.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func TODO() Logger {
+	return Background()
+}
+
+// Background retrieves the fallback logger. It should not be called before
+// that logger was initialized by the program and not by code that should
+// better receive a logger via its parameters. TODO can be used as a temporary
+// solution for such code.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func Background() Logger {
+	if globalLogger != nil && contextualLogger {
+		return *globalLogger
+	}
+
+	return klogLogger
+}
+
+// LoggerWithValues returns logger.WithValues(...kv) when
+// contextual logging is enabled, otherwise the logger.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func LoggerWithValues(logger Logger, kv ...interface{}) Logger {
+	if contextualLoggingEnabled {
+		return logger.WithValues(kv...)
+	}
+	return logger
+}
+
+// LoggerWithName returns logger.WithName(name) when contextual logging is
+// enabled, otherwise the logger.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func LoggerWithName(logger Logger, name string) Logger {
+	if contextualLoggingEnabled {
+		return logger.WithName(name)
+	}
+	return logger
+}
+
+// NewContext returns logr.NewContext(ctx, logger) when
+// contextual logging is enabled, otherwise ctx.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewContext(ctx context.Context, logger Logger) context.Context {
+	if contextualLoggingEnabled {
+		return logr.NewContext(ctx, logger)
+	}
+	return ctx
+}

--- a/contextual_test.go
+++ b/contextual_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog_test
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+)
+
+func ExampleSetLogger() {
+	// Logger is only used as backend, Background() returns klogr.
+	klog.SetLogger(logr.Discard())
+	fmt.Printf("logger after SetLogger: %T\n", klog.Background().GetSink())
+
+	// Logger is only used as backend, Background() returns klogr.
+	klog.SetLoggerWithOptions(logr.Discard(), klog.ContextualLogger(false))
+	fmt.Printf("logger after SetLoggerWithOptions with ContextualLogger(false): %T\n", klog.Background().GetSink())
+
+	// Logger is used as backend and directly.
+	klog.SetLoggerWithOptions(logr.Discard(), klog.ContextualLogger(true))
+	fmt.Printf("logger after SetLoggerWithOptions with ContextualLogger(true): %T\n", klog.Background().GetSink())
+
+	// Output:
+	// logger after SetLogger: *klog.klogger
+	// logger after SetLoggerWithOptions with ContextualLogger(false): *klog.klogger
+	// logger after SetLoggerWithOptions with ContextualLogger(true): logr.discardLogSink
+}

--- a/imports.go
+++ b/imports.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"github.com/go-logr/logr"
+)
+
+// The reason for providing these aliases is to allow code to work with logr
+// without directly importing it.
+
+// Logger in this package is exactly the same as logr.Logger.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type Logger = logr.Logger
+
+// LogSink in this package is exactly the same as logr.LogSink.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type LogSink = logr.LogSink
+
+// Runtimeinfo in this package is exactly the same as logr.RuntimeInfo.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type RuntimeInfo = logr.RuntimeInfo
+
+var (
+	// New is an alias for logr.New.
+	//
+	// Experimental
+	//
+	// Notice: This variable is EXPERIMENTAL and may be changed or removed in a
+	// later release.
+	New = logr.New
+)

--- a/k8s_references.go
+++ b/k8s_references.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+)
+
+// ObjectRef references a kubernetes object
+type ObjectRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+func (ref ObjectRef) String() string {
+	if ref.Namespace != "" {
+		return fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)
+	}
+	return ref.Name
+}
+
+// MarshalLog ensures that loggers with support for structured output will log
+// as a struct by removing the String method via a custom type.
+func (ref ObjectRef) MarshalLog() interface{} {
+	type or ObjectRef
+	return or(ref)
+}
+
+var _ logr.Marshaler = ObjectRef{}
+
+// KMetadata is a subset of the kubernetes k8s.io/apimachinery/pkg/apis/meta/v1.Object interface
+// this interface may expand in the future, but will always be a subset of the
+// kubernetes k8s.io/apimachinery/pkg/apis/meta/v1.Object interface
+type KMetadata interface {
+	GetName() string
+	GetNamespace() string
+}
+
+// KObj returns ObjectRef from ObjectMeta
+func KObj(obj KMetadata) ObjectRef {
+	if obj == nil {
+		return ObjectRef{}
+	}
+	if val := reflect.ValueOf(obj); val.Kind() == reflect.Ptr && val.IsNil() {
+		return ObjectRef{}
+	}
+
+	return ObjectRef{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}
+
+// KRef returns ObjectRef from name and namespace
+func KRef(namespace, name string) ObjectRef {
+	return ObjectRef{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+// KObjs returns slice of ObjectRef from an slice of ObjectMeta
+func KObjs(arg interface{}) []ObjectRef {
+	s := reflect.ValueOf(arg)
+	if s.Kind() != reflect.Slice {
+		return nil
+	}
+	objectRefs := make([]ObjectRef, 0, s.Len())
+	for i := 0; i < s.Len(); i++ {
+		if v, ok := s.Index(i).Interface().(KMetadata); ok {
+			objectRefs = append(objectRefs, KObj(v))
+		} else {
+			return nil
+		}
+	}
+	return objectRefs
+}

--- a/klogr.go
+++ b/klogr.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/internal/serialize"
+)
+
+// NewKlogr returns a logger that is functionally identical to
+// klogr.NewWithOptions(klogr.FormatKlog), i.e. it passes through to klog. The
+// difference is that it uses a simpler implementation.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewKlogr() Logger {
+	return New(&klogger{})
+}
+
+// klogger is a subset of klogr/klogr.go. It had to be copied to break an
+// import cycle (klogr wants to use klog, and klog wants to use klogr).
+type klogger struct {
+	level     int
+	callDepth int
+	prefix    string
+	values    []interface{}
+}
+
+func (l *klogger) Init(info logr.RuntimeInfo) {
+	l.callDepth += info.CallDepth
+}
+
+func (l klogger) Info(level int, msg string, kvList ...interface{}) {
+	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	if l.prefix != "" {
+		msg = l.prefix + ": " + msg
+	}
+	V(Level(level)).InfoSDepth(l.callDepth+1, msg, append(trimmed[0], trimmed[1]...)...)
+}
+
+func (l klogger) Enabled(level int) bool {
+	return V(Level(level)).Enabled()
+}
+
+func (l klogger) Error(err error, msg string, kvList ...interface{}) {
+	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	if l.prefix != "" {
+		msg = l.prefix + ": " + msg
+	}
+	ErrorSDepth(l.callDepth+1, err, msg, append(trimmed[0], trimmed[1]...)...)
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l klogger) WithName(name string) logr.LogSink {
+	if len(l.prefix) > 0 {
+		l.prefix = l.prefix + "/"
+	}
+	l.prefix += name
+	return &l
+}
+
+func (l klogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.values = serialize.WithValues(l.values, kvList)
+	return &l
+}
+
+func (l klogger) WithCallDepth(depth int) logr.LogSink {
+	l.callDepth += depth
+	return &l
+}
+
+var _ logr.LogSink = &klogger{}
+var _ logr.CallDepthLogSink = &klogger{}

--- a/ktesting/example/example_test.go
+++ b/ktesting/example/example_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package example
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/internal/test"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init" // add command line flags
+)
+
+func TestKlogr(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	exampleOutput(logger)
+}
+
+type pair struct {
+	a, b int
+}
+
+func (p pair) String() string {
+	return fmt.Sprintf("(%d, %d)", p.a, p.b)
+}
+
+var _ fmt.Stringer = pair{}
+
+type err struct {
+	msg string
+}
+
+func (e err) Error() string {
+	return "failed: " + e.msg
+}
+
+var _ error = err{}
+
+func exampleOutput(logger klog.Logger) {
+	logger.Info("hello world")
+	logger.Error(err{msg: "some error"}, "failed")
+	logger.V(1).Info("verbosity 1")
+	logger.WithName("main").WithName("helper").Info("with prefix")
+	obj := test.KMetadataMock{Name: "joe", NS: "kube-system"}
+	logger.Info("key/value pairs",
+		"int", 1,
+		"float", 2.0,
+		"pair", pair{a: 1, b: 2},
+		"raw", obj,
+		"kobj", klog.KObj(obj),
+	)
+	logger.V(4).Info("info message level 4")
+	logger.V(5).Info("info message level 5")
+	logger.V(6).Info("info message level 6")
+}

--- a/ktesting/init/init.go
+++ b/ktesting/init/init.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package init registers the command line flags for k8s.io/klogr/testing in
+// the flag.CommandLine. This is done during initialization, so merely
+// importing it is enough.
+//
+// Experimental
+//
+// Notice: This package is EXPERIMENTAL and may be changed or removed in a
+// later release.
+package init
+
+import (
+	"flag"
+
+	"k8s.io/klog/v2/ktesting"
+)
+
+func init() {
+	ktesting.DefaultConfig.AddFlags(flag.CommandLine)
+}

--- a/ktesting/options.go
+++ b/ktesting/options.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"flag"
+	"strconv"
+
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+// Config influences logging in a test logger. To make this configurable via
+// command line flags, instantiate this once per program and use AddFlags to
+// bind command line flags to the instance before passing it to NewTestContext.
+//
+// Must be constructed with NewConfig.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type Config struct {
+	vstate *verbosity.VState
+	co     configOptions
+}
+
+// ConfigOption implements functional parameters for NewConfig.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type ConfigOption func(co *configOptions)
+
+type configOptions struct {
+	verbosityFlagName string
+	vmoduleFlagName   string
+	verbosityDefault  int
+}
+
+// VerbosityFlagName overrides the default -testing.v for the verbosity level.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func VerbosityFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+		co.verbosityFlagName = name
+	}
+}
+
+// VModulFlagName overrides the default -testing.vmodule for the per-module
+// verbosity levels.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func VModuleFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+		co.vmoduleFlagName = name
+	}
+}
+
+// Verbosity overrides the default verbosity level of 5. That default is higher
+// than in klog itself because it enables logging entries for "the steps
+// leading up to errors and warnings" and "troubleshooting" (see
+// https://github.com/kubernetes/community/blob/9406b4352fe2d5810cb21cc3cb059ce5886de157/contributors/devel/sig-instrumentation/logging.md#logging-conventions),
+// which is useful when debugging a failed test. `go test` only shows the log
+// output for failed tests. To see all output, use `go test -v`.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func Verbosity(level int) ConfigOption {
+	return func(co *configOptions) {
+		co.verbosityDefault = level
+	}
+}
+
+// NewConfig returns a configuration with recommended defaults and optional
+// modifications. Command line flags are not bound to any FlagSet yet.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewConfig(opts ...ConfigOption) *Config {
+	c := &Config{
+		co: configOptions{
+			verbosityFlagName: "testing.v",
+			vmoduleFlagName:   "testing.vmodule",
+			verbosityDefault:  5,
+		},
+	}
+	for _, opt := range opts {
+		opt(&c.co)
+	}
+
+	c.vstate = verbosity.New()
+	c.vstate.V().Set(strconv.FormatInt(int64(c.co.verbosityDefault), 10))
+	return c
+}
+
+// AddFlags registers the command line flags that control the configuration.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func (c *Config) AddFlags(fs *flag.FlagSet) {
+	fs.Var(c.vstate.V(), c.co.verbosityFlagName, "number for the log level verbosity of the testing logger")
+	fs.Var(c.vstate.VModule(), c.co.vmoduleFlagName, "comma-separated list of pattern=N log level settings for files matching the patterns")
+}

--- a/ktesting/setup.go
+++ b/ktesting/setup.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+// DefaultConfig is the global default logging configuration for a unit
+// test. It is used by NewTestContext and k8s.io/klogr/testing/init.
+//
+// Experimental
+//
+// Notice: This variable is EXPERIMENTAL and may be changed or removed in a
+// later release.
+var DefaultConfig = NewConfig()
+
+// NewTestContext returns a logger and context for use in a unit test case or
+// benchmark. The tl parameter can be a testing.T or testing.B pointer that
+// will receive all log output. Importing k8s.io/klogr/testing/init will add
+// command line flags that modify the configuration of that log output.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewTestContext(tl TL) (logr.Logger, context.Context) {
+	logger := NewLogger(tl, DefaultConfig)
+	ctx := logr.NewContext(context.Background(), logger)
+	return logger, ctx
+
+}

--- a/ktesting/testinglogger.go
+++ b/ktesting/testinglogger.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testinglogger contains an implementation of the logr interface
+// which is logging through a function like testing.TB.Log function.
+// Therefore it can be used in standard Go tests and Gingko test suites
+// to ensure that output is associated with the currently running test.
+//
+// Serialization of the structured log parameters is done in the same way
+// as for klog.InfoS.
+//
+// Experimental
+//
+// Notice: This package is EXPERIMENTAL and may be changed or removed in a
+// later release.
+package ktesting
+
+import (
+	"bytes"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+// TL is the relevant subset of testing.TB.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type TL interface {
+	Helper()
+	Log(args ...interface{})
+}
+
+// NewLogger constructs a new logger for the given test interface.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewLogger(t TL, c *Config) logr.Logger {
+	return logr.New(&tlogger{
+		t:      t,
+		prefix: "",
+		values: nil,
+		config: c,
+	})
+}
+
+type tlogger struct {
+	t      TL
+	prefix string
+	values []interface{}
+	config *Config
+}
+
+func (l *tlogger) Init(info logr.RuntimeInfo) {
+}
+
+func (l *tlogger) GetCallStackHelper() func() {
+	return l.t.Helper
+}
+
+func (l *tlogger) Info(level int, msg string, kvList ...interface{}) {
+	l.t.Helper()
+	buffer := &bytes.Buffer{}
+	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	serialize.KVListFormat(buffer, trimmed[0]...)
+	serialize.KVListFormat(buffer, trimmed[1]...)
+	l.log("INFO", msg, buffer)
+}
+
+func (l *tlogger) Enabled(level int) bool {
+	return l.config.vstate.Enabled(verbosity.Level(level), 1)
+}
+
+func (l *tlogger) Error(err error, msg string, kvList ...interface{}) {
+	l.t.Helper()
+	buffer := &bytes.Buffer{}
+	if err != nil {
+		serialize.KVListFormat(buffer, "err", err)
+	}
+	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	serialize.KVListFormat(buffer, trimmed[0]...)
+	serialize.KVListFormat(buffer, trimmed[1]...)
+	l.log("ERROR", msg, buffer)
+}
+
+func (l *tlogger) log(what, msg string, buffer *bytes.Buffer) {
+	l.t.Helper()
+	args := []interface{}{what}
+	if l.prefix != "" {
+		args = append(args, l.prefix+":")
+	}
+	args = append(args, msg)
+	if buffer.Len() > 0 {
+		// Skip leading space inserted by serialize.KVListFormat.
+		args = append(args, string(buffer.Bytes()[1:]))
+	}
+	l.t.Log(args...)
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l *tlogger) WithName(name string) logr.LogSink {
+	new := *l
+	if len(l.prefix) > 0 {
+		new.prefix = l.prefix + "/"
+	}
+	new.prefix += name
+	return &new
+}
+
+func (l *tlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	new := *l
+	new.values = serialize.WithValues(l.values, kvList)
+	return &new
+}
+
+var _ logr.LogSink = &tlogger{}
+var _ logr.CallStackHelperLogSink = &tlogger{}

--- a/ktesting/testinglogger_test.go
+++ b/ktesting/testinglogger_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ktesting
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestInfo(t *testing.T) {
+	tests := map[string]struct {
+		text           string
+		withValues     []interface{}
+		keysAndValues  []interface{}
+		names          []string
+		err            error
+		expectedOutput string
+	}{
+		"should log with values passed to keysAndValues": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO test akey="avalue"
+`,
+		},
+		"should support single name": {
+			names:         []string{"hello"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO hello: test akey="avalue"
+`,
+		},
+		"should support multiple names": {
+			names:         []string{"hello", "world"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO hello/world: test akey="avalue"
+`,
+		},
+		"should not print duplicate keys with the same value": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
+			expectedOutput: `INFO test akey="avalue"
+`,
+		},
+		"should only print the last duplicate key when the values are passed to Info": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
+			expectedOutput: `INFO test akey="avalue2"
+`,
+		},
+		"should only print the duplicate key that is passed to Info if one was passed to the logger": {
+			withValues:    []interface{}{"akey", "avalue"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue"},
+			expectedOutput: `INFO test akey="avalue"
+`,
+		},
+		"should only print the key passed to Info when one is already set on the logger": {
+			withValues:    []interface{}{"akey", "avalue"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue2"},
+			expectedOutput: `INFO test akey="avalue2"
+`,
+		},
+		"should correctly handle odd-numbers of KVs": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
+			expectedOutput: `INFO test akey="avalue" akey2="(MISSING)"
+`,
+		},
+		"should correctly html characters": {
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "<&>"},
+			expectedOutput: `INFO test akey="<&>"
+`,
+		},
+		"should correctly handle odd-numbers of KVs in both log values and Info args": {
+			withValues:    []interface{}{"basekey1", "basevar1", "basekey2"},
+			text:          "test",
+			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
+			expectedOutput: `INFO test basekey1="basevar1" basekey2="(MISSING)" akey="avalue" akey2="(MISSING)"
+`,
+		},
+		"should correctly print regular error types": {
+			text:          "test",
+			keysAndValues: []interface{}{"err", errors.New("whoops")},
+			expectedOutput: `INFO test err="whoops"
+`,
+		},
+		"should correctly print regular error types when using logr.Error": {
+			text: "test",
+			err:  errors.New("whoops"),
+			expectedOutput: `ERROR test err="whoops"
+`,
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			var buffer logToBuf
+			klogr := NewLogger(&buffer, NewConfig())
+			for _, name := range test.names {
+				klogr = klogr.WithName(name)
+			}
+			klogr = klogr.WithValues(test.withValues...)
+
+			if test.err != nil {
+				klogr.Error(test.err, test.text, test.keysAndValues...)
+			} else {
+				klogr.Info(test.text, test.keysAndValues...)
+			}
+
+			actual := buffer.String()
+			if actual != test.expectedOutput {
+				t.Errorf("expected %q did not match actual %q", test.expectedOutput, actual)
+			}
+		})
+	}
+}
+
+func TestCallDepth(t *testing.T) {
+	logger := NewLogger(t, NewConfig())
+	logger.Info("hello world")
+}
+
+type logToBuf struct {
+	bytes.Buffer
+}
+
+func (l *logToBuf) Helper() {
+}
+
+func (l *logToBuf) Log(args ...interface{}) {
+	for i, arg := range args {
+		if i > 0 {
+			l.Write([]byte(" "))
+		}
+		l.Write([]byte(fmt.Sprintf("%s", arg)))
+	}
+	l.Write([]byte("\n"))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Contextual logging enables several new use cases as shown in https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging.

This PR is an implementation of the logging side of the [revised KEP (currently pending in review)](https://github.com/kubernetes/enhancements/pull/3222). A PR with the logcheck changes will be filed separately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related-to: https://github.com/kubernetes/enhancements/issues/3077

**Special notes for your reviewer**:

We probably should merge the KEP change first.

This PR is best looked at commit-by-commit.

**Release note**:
```release-note
Additional API calls for [contextual logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging).
```