### PR TITLE
test: fix Go version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-versions: [1.14.x, 1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.14, 1.15, 1.16, 1.17]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

The matrix didn't really have an effect, all tests ran with the same (default?)
Go version. For example, the "1.17.x, ubuntu-latest" test
https://github.com/kubernetes/klog/runs/5215345316?check_suite_focus=true
for https://github.com/kubernetes/klog/pull/297 complained about functions that
are available in 1.17:

```
Error: logcheck/pkg/filter_test.go:28:12: undefined: os.WriteFile
Error: logcheck/pkg/filter_test.go:132:14: undefined: os.WriteFile
```

**Special notes for your reviewer**:

The same issue was noticed and fixed in logr, probably because the code there was copied from here:
https://github.com/go-logr/logr/pull/135

**Release note**:
```release-note
NONE
```