### PR TITLE
tests: stop testing with Go 1.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14, 1.15, 1.16, 1.17]
+        go-version: [1.15, 1.16, 1.17]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

Go 1.14.x is no longer supported upstream and doesn't have some newer
functionality like testing.T.TempDir, something that will get used in https://github.com/kubernetes/klog/pull/297

Core klog may still work with Go < 1.15, it just doesn't get tested anymore.

**Release note**:
```release-note
NONE
```
