### PR TITLE
SetLoggerWithOptions: support flushing

### DIFF
--- a/contextual_test.go
+++ b/contextual_test.go
@@ -43,3 +43,16 @@ func ExampleSetLogger() {
 	// logger after SetLoggerWithOptions with ContextualLogger(false): *klog.klogger
 	// logger after SetLoggerWithOptions with ContextualLogger(true): logr.discardLogSink
 }
+
+func ExampleFlushLogger() {
+	defer klog.ClearLogger()
+
+	// This simple logger doesn't need flushing, but others might.
+	klog.SetLoggerWithOptions(logr.Discard(), klog.FlushLogger(func() {
+		fmt.Print("flushing...")
+	}))
+	klog.Flush()
+
+	// Output:
+	// flushing...
+}

--- a/klog.go
+++ b/klog.go
@@ -1097,6 +1097,9 @@ func (l *loggingT) flushAll() {
 			file.Sync()  // ignore error
 		}
 	}
+	if globalLoggerOptions.flush != nil {
+		globalLoggerOptions.flush()
+	}
 }
 
 // CopyStandardLogTo arranges for messages written to the Go "log" package's


### PR DESCRIPTION
**What this PR does / why we need it**:

When setting a logger that buffers data in memory, we want klog.Flush to flush
that data. For that the caller has to provide an additional callback because
logr.Logger has no API for flushing.

**Special notes for your reviewer**:

Planned usage in Kubernetes: https://github.com/pohly/kubernetes/pull/new/klog-flush

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
SetLoggerWithOptions: support flushing the logger through klog.Flush and klog.FlushAndExit
```