### PR TITLE
Cleanup OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-  - jayunit100
-  - hoegaarden
-  - andyxning
-  - neolit123
   - pohly
-  - yagonobre
-  - vincepri
-  - detiber
 approvers:
   - dims
   - thockin
-  - justinsb
-  - tallclair
-  - piosz
-  - brancz
-  - lavalamp
   - serathius
+emeritus_approvers:
+  - brancz
+  - justinsb
+  - lavalamp
+  - piosz
+  - tallclair


### PR DESCRIPTION
Run 
```
maintainers prune --repository-devstats=kubernetes/klog
--repository-github=kubernetes/klog --dryrun=false
Running script : 03-17-2022 18:10:19
Found 0 unique aliases
Found 16 unique users
.......

>>>>> Contributions from kubernetes/klog devstats repo and
kubernetes/klog github repo : 7
>>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
dims : 115 : 44
pohly : 298 : 33
serathius : 85 : 18
thockin : 56 : 8
jayunit100 : 2 : 2
neolit123 : 3 : 2
vincepri : 2 : 0

>>>>> Missing Contributions in kubernetes/klog (devstats == 0): 9
andyxning
brancz
detiber
hoegaarden
justinsb
lavalamp
piosz
tallclair
yagonobre

>>>>> Low reviews/approvals in kubernetes/klog (GH pr comments <= 10 &&
devstats <=20): 3
jayunit100
neolit123
vincepri
```

```release-note
NONE
```
/cc @dims @pohly @ehashman 