### PR TITLE
StopFlushDaemon: document flushing on shutdown

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -1077,9 +1077,9 @@ func (f *flushDaemon) isRunning() bool {
 	return f.stopC != nil
 }
 
-// StopFlushDaemon stops the flush daemon, if running.
+// StopFlushDaemon stops the flush daemon, if running, and flushes once.
 // This prevents klog from leaking goroutines on shutdown. After stopping
-// the daemon, you can still manually flush buffers by calling Flush().
+// the daemon, you can still manually flush buffers again by calling Flush().
 func StopFlushDaemon() {
 	logging.flushD.stop()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is how it was originally implemented and people may have started to rely
on that now after inspecting the source code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

See https://github.com/kubernetes/kubernetes/pull/108725#discussion_r831169438

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
StopFlushDaemon: it is guaranteed to flush once.
```
