### PR TITLE
replace KObjs with KObjSlice

### DIFF
--- a/examples/benchmarks/benchmarks_test.go
+++ b/examples/benchmarks/benchmarks_test.go
@@ -75,7 +75,7 @@ func BenchmarkOutput(b *testing.B) {
 		tests = append(tests, testcase{
 			name: fmt.Sprintf("objects/%d", length),
 			generate: func() interface{} {
-				return klog.KObjs(arg)
+				return klog.KObjSlice(arg)
 			},
 		})
 	}

--- a/examples/benchmarks/benchmarks_test.go
+++ b/examples/benchmarks/benchmarks_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmarks
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	verbosityThreshold = 10
+)
+
+func init() {
+	// klog gets configured so that it writes to a single output file that
+	// will be set during tests with SetOutput.
+	klog.InitFlags(nil)
+	flag.Set("v", fmt.Sprintf("%d", verbosityThreshold))
+	flag.Set("log_file", "/dev/null")
+	flag.Set("logtostderr", "false")
+	flag.Set("alsologtostderr", "false")
+	flag.Set("stderrthreshold", "10")
+}
+
+type testcase struct {
+	name     string
+	generate func() interface{}
+}
+
+func BenchmarkOutput(b *testing.B) {
+	// We'll run each benchmark for different output formatting.
+	configs := map[string]struct {
+		init, cleanup func()
+	}{
+		"klog": {
+			init: func() { klog.SetOutput(discard{}) },
+		},
+		"zapr": {
+			init:    func() { klog.SetLogger(newZaprLogger()) },
+			cleanup: func() { klog.ClearLogger() },
+		},
+	}
+
+	// Each benchmark tests formatting of one key/value pair, with
+	// different values. The order is relevant here.
+	var tests []testcase
+	for length := 0; length <= 100; length += 10 {
+		arg := make([]interface{}, length)
+		for i := 0; i < length; i++ {
+			arg[i] = KMetadataMock{Name: "a", NS: "a"}
+		}
+		tests = append(tests, testcase{
+			name: fmt.Sprintf("objects/%d", length),
+			generate: func() interface{} {
+				return klog.KObjs(arg)
+			},
+		})
+	}
+
+	// Verbosity checks may influence the result.
+	verbosity := map[string]func(value interface{}){
+		"no-verbosity-check": func(value interface{}) {
+			klog.InfoS("test", "key", value)
+		},
+		"pass-verbosity-check": func(value interface{}) {
+			klog.V(verbosityThreshold).InfoS("test", "key", value)
+		},
+		"fail-verbosity-check": func(value interface{}) {
+			klog.V(verbosityThreshold+1).InfoS("test", "key", value)
+		},
+	}
+
+	for name, config := range configs {
+		b.Run(name, func(b *testing.B) {
+			if config.cleanup != nil {
+				defer config.cleanup()
+			}
+			config.init()
+
+			for name, logCall := range verbosity {
+				b.Run(name, func(b *testing.B) {
+					for _, testcase := range tests {
+						b.Run(testcase.name, func(b *testing.B) {
+							b.ResetTimer()
+							for i := 0; i < b.N; i++ {
+								logCall(testcase.generate())
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func newZaprLogger() logr.Logger {
+	encoderConfig := &zapcore.EncoderConfig{
+		MessageKey:     "msg",
+		CallerKey:      "caller",
+		NameKey:        "logger",
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+	encoder := zapcore.NewJSONEncoder(*encoderConfig)
+	zapV := -zapcore.Level(verbosityThreshold)
+	core := zapcore.NewCore(encoder, zapcore.AddSync(discard{}), zapV)
+	l := zap.New(core, zap.WithCaller(true))
+	logger := zapr.NewLoggerWithOptions(l, zapr.LogInfoLevel("v"), zapr.ErrorKey("err"))
+	return logger
+}
+
+type KMetadataMock struct {
+	Name, NS string
+}
+
+func (m KMetadataMock) GetName() string {
+	return m.Name
+}
+func (m KMetadataMock) GetNamespace() string {
+	return m.NS
+}
+
+type discard struct{}
+
+var _ io.Writer = discard{}
+
+func (discard) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/klog_test.go
+++ b/klog_test.go
@@ -631,7 +631,7 @@ func BenchmarkHeaderWithDir(b *testing.B) {
 }
 
 // Ensure that benchmarks have side effects to avoid compiler optimization
-var result ObjectRef
+var result interface{}
 var enabled bool
 
 func BenchmarkV(b *testing.B) {
@@ -657,6 +657,29 @@ func BenchmarkKObj(b *testing.B) {
 		r = KObj(&a)
 	}
 	result = r
+}
+
+// BenchmarkKObjs measures the (pretty typical) case
+// where KObjs is used in a V(5).InfoS call that never
+// emits a log entry because verbosity is lower than 5.
+// For performance when the result of KObjs gets formatted,
+// see examples/benchmarks.
+func BenchmarkKObjs(b *testing.B) {
+	for length := 0; length <= 100; length += 10 {
+		b.Run(fmt.Sprintf("%d", length), func(b *testing.B) {
+			arg := make([]interface{}, length)
+			for i := 0; i < length; i++ {
+				arg[i] = test.KMetadataMock{Name: "a", NS: "a"}
+			}
+			b.ResetTimer()
+
+			var r interface{}
+			for i := 0; i < b.N; i++ {
+				r = KObjs(arg)
+			}
+			result = r
+		})
+	}
 }
 
 func BenchmarkLogs(b *testing.B) {

--- a/test/output.go
+++ b/test/output.go
@@ -270,6 +270,47 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 			expectedOutput: `I output.go:<LINE>] "test" pods=[kube-system/pod-1 kube-system/pod-2]
 `,
 		},
+		"KObjSlice okay": {
+			text: "test",
+			values: []interface{}{"pods",
+				klog.KObjSlice([]interface{}{
+					&kmeta{Name: "pod-1", Namespace: "kube-system"},
+					&kmeta{Name: "pod-2", Namespace: "kube-system"},
+				})},
+			expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 kube-system/pod-2]"
+`,
+		},
+		"KObjSlice nil arg": {
+			text: "test",
+			values: []interface{}{"pods",
+				klog.KObjSlice(nil)},
+			expectedOutput: `I output.go:<LINE>] "test" pods="[]"
+`,
+		},
+		"KObjSlice int arg": {
+			text: "test",
+			values: []interface{}{"pods",
+				klog.KObjSlice(1)},
+			expectedOutput: `I output.go:<LINE>] "test" pods="<KObjSlice needs a slice, got type int>"
+`,
+		},
+		"KObjSlice nil entry": {
+			text: "test",
+			values: []interface{}{"pods",
+				klog.KObjSlice([]interface{}{
+					&kmeta{Name: "pod-1", Namespace: "kube-system"},
+					nil,
+				})},
+			expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 <nil>]"
+`,
+		},
+		"KObjSlice ints": {
+			text: "test",
+			values: []interface{}{"ints",
+				klog.KObjSlice([]int{1, 2, 3})},
+			expectedOutput: `I output.go:<LINE>] "test" ints="<KObjSlice needs a slice of values implementing KMetadata, got type int>"
+`,
+		},
 		"regular error types as value": {
 			text:   "test",
 			values: []interface{}{"err", errors.New("whoops")},

--- a/test/zapr.go
+++ b/test/zapr.go
@@ -69,6 +69,26 @@ func ZaprOutputMappingDirect() map[string]string {
 `: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":[{"name":"pod-1","namespace":"kube-system"},{"name":"pod-2","namespace":"kube-system"}]}
 `,
 
+		`I output.go:<LINE>] "test" pods="[kube-system/pod-1 kube-system/pod-2]"
+`: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":[{"name":"pod-1","namespace":"kube-system"},{"name":"pod-2","namespace":"kube-system"}]}
+`,
+
+		`I output.go:<LINE>] "test" pods="[]"
+`: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":null}
+`,
+
+		`I output.go:<LINE>] "test" pods="<KObjSlice needs a slice, got type int>"
+`: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":"<KObjSlice needs a slice, got type int>"}
+`,
+
+		`I output.go:<LINE>] "test" ints="<KObjSlice needs a slice of values implementing KMetadata, got type int>"
+`: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"ints":"<KObjSlice needs a slice of values implementing KMetadata, got type int>"}
+`,
+
+		`I output.go:<LINE>] "test" pods="[kube-system/pod-1 <nil>]"
+`: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":[{"name":"pod-1","namespace":"kube-system"},null]}
+`,
+
 		`I output.go:<LINE>] "test" akey="avalue"
 `: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"akey":"avalue"}
 `,


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes preparing parameters for a log call run in constant time, regardless of the number of slice entries:

```
$ $GOPATH/bin/benchstat /tmp/old /tmp/new
name          old time/op    new time/op    delta
KObjs/0-36       178ns ± 1%     156ns ± 3%  -12.01%  (p=0.008 n=5+5)
KObjs/10-36     1.17µs ± 2%    0.16µs ± 4%  -86.71%  (p=0.008 n=5+5)
KObjs/20-36     1.99µs ± 1%    0.15µs ± 3%  -92.21%  (p=0.008 n=5+5)
KObjs/30-36     2.77µs ± 2%    0.15µs ± 4%  -94.45%  (p=0.008 n=5+5)
KObjs/40-36     3.58µs ± 1%    0.15µs ± 2%  -95.83%  (p=0.008 n=5+5)
KObjs/50-36     4.38µs ± 1%    0.16µs ± 1%  -96.44%  (p=0.008 n=5+5)
KObjs/60-36     5.27µs ± 2%    0.15µs ± 3%  -97.08%  (p=0.008 n=5+5)
KObjs/70-36     5.90µs ± 1%    0.15µs ± 4%  -97.40%  (p=0.008 n=5+5)
KObjs/80-36     6.82µs ± 1%    0.15µs ± 5%  -97.76%  (p=0.008 n=5+5)
KObjs/90-36     7.41µs ± 2%    0.15µs ± 2%  -97.92%  (p=0.008 n=5+5)
KObjs/100-36    8.25µs ± 3%    0.15µs ± 2%  -98.17%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
KObjs/0-36       48.0B ± 0%     40.0B ± 0%  -16.67%  (p=0.008 n=5+5)
KObjs/10-36       368B ± 0%       40B ± 0%  -89.13%  (p=0.008 n=5+5)
KObjs/20-36       688B ± 0%       40B ± 0%  -94.19%  (p=0.008 n=5+5)
KObjs/30-36     1.07kB ± 0%    0.04kB ± 0%  -96.27%  (p=0.008 n=5+5)
KObjs/40-36     1.33kB ± 0%    0.04kB ± 0%  -96.99%  (p=0.008 n=5+5)
KObjs/50-36     1.84kB ± 0%    0.04kB ± 0%  -97.83%  (p=0.008 n=5+5)
KObjs/60-36     2.10kB ± 0%    0.04kB ± 0%  -98.09%  (p=0.008 n=5+5)
KObjs/70-36     2.35kB ± 0%    0.04kB ± 0%  -98.30%  (p=0.008 n=5+5)
KObjs/80-36     2.74kB ± 0%    0.04kB ± 0%  -98.54%  (p=0.008 n=5+5)
KObjs/90-36     3.12kB ± 0%    0.04kB ± 0%  -98.72%  (p=0.008 n=5+5)
KObjs/100-36    3.25kB ± 0%    0.04kB ± 0%  -98.77%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
KObjs/0-36        2.00 ± 0%      2.00 ± 0%     ~     (all equal)
KObjs/10-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/20-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/30-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/40-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/50-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/60-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/70-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/80-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/90-36       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
KObjs/100-36      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related-to: https://github.com/kubernetes/kubernetes/issues/106945

**Special notes for your reviewer**:


**Release note**:
```release-note
KObjs is deprecated. KObjSlice should be used instead because it has better performance.
```