### PR TITLE
Trim duplicates

### DIFF
--- a/internal/serialize/keyvalues_test.go
+++ b/internal/serialize/keyvalues_test.go
@@ -19,6 +19,7 @@ package serialize_test
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -147,5 +148,159 @@ No whitespace.`,
 		if b.String() != d.want {
 			t.Errorf("KVListFormat error:\n got:\n\t%s\nwant:\t%s", b.String(), d.want)
 		}
+	}
+}
+
+func TestDuplicates(t *testing.T) {
+	for name, test := range map[string]struct {
+		first, second   []interface{}
+		expectedTrimmed [][]interface{}
+	}{
+		"empty": {
+			expectedTrimmed: [][]interface{}{{}, {}},
+		},
+		"no-duplicates": {
+			first:  makeKV("a", 3),
+			second: makeKV("b", 3),
+			expectedTrimmed: [][]interface{}{
+				makeKV("a", 3),
+				makeKV("b", 3),
+			},
+		},
+		"all-duplicates": {
+			first:  makeKV("a", 3),
+			second: makeKV("a", 3),
+			expectedTrimmed: [][]interface{}{
+				{},
+				makeKV("a", 3),
+			},
+		},
+		"start-duplicate": {
+			first:  append([]interface{}{"x", 1}, makeKV("a", 3)...),
+			second: append([]interface{}{"x", 2}, makeKV("b", 3)...),
+			expectedTrimmed: [][]interface{}{
+				makeKV("a", 3),
+				append([]interface{}{"x", 2}, makeKV("b", 3)...),
+			},
+		},
+		"subset-first": {
+			first:  append([]interface{}{"x", 1}, makeKV("a", 3)...),
+			second: append([]interface{}{"x", 2}, makeKV("a", 3)...),
+			expectedTrimmed: [][]interface{}{
+				{},
+				append([]interface{}{"x", 2}, makeKV("a", 3)...),
+			},
+		},
+		"subset-second": {
+			first:  append([]interface{}{"x", 1}, makeKV("a", 1)...),
+			second: append([]interface{}{"x", 2}, makeKV("b", 2)...),
+			expectedTrimmed: [][]interface{}{
+				makeKV("a", 1),
+				append([]interface{}{"x", 2}, makeKV("b", 2)...),
+			},
+		},
+		"end-duplicate": {
+			first:  append(makeKV("a", 3), "x", 1),
+			second: append(makeKV("b", 3), "x", 2),
+			expectedTrimmed: [][]interface{}{
+				makeKV("a", 3),
+				append(makeKV("b", 3), "x", 2),
+			},
+		},
+		"middle-duplicate": {
+			first:  []interface{}{"a-0", 0, "x", 1, "a-1", 2},
+			second: []interface{}{"b-0", 0, "x", 2, "b-1", 2},
+			expectedTrimmed: [][]interface{}{
+				{"a-0", 0, "a-1", 2},
+				{"b-0", 0, "x", 2, "b-1", 2},
+			},
+		},
+		"internal-duplicates": {
+			first:  []interface{}{"a", 0, "x", 1, "a", 2},
+			second: []interface{}{"b", 0, "x", 2, "b", 2},
+			expectedTrimmed: [][]interface{}{
+				{"a", 2},
+				{"x", 2, "b", 2},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actual := serialize.TrimDuplicates(test.first, test.second)
+			expectEqual(t, "trimmed key/value pairs", test.expectedTrimmed, actual)
+		})
+	}
+}
+
+// BenchmarkTrimDuplicates checks performance when TrimDuplicates is called with two slices.
+// In practice that is how the function is used.
+func BenchmarkTrimDuplicates(b *testing.B) {
+	for firstLength := 0; firstLength < 10; firstLength++ {
+		firstA := makeKV("a", firstLength)
+		for secondLength := 0; secondLength < 10; secondLength++ {
+			secondA := makeKV("a", secondLength)
+			secondB := makeKV("b", secondLength)
+			b.Run(fmt.Sprintf("%dx%d", firstLength, secondLength), func(b *testing.B) {
+				// This is the most common case: all key/value pairs are kept.
+				b.Run("no-duplicates", func(b *testing.B) {
+					expected := [][]interface{}{firstA, secondB}
+					benchTrimDuplicates(b, expected, firstA, secondB)
+				})
+
+				// Fairly unlikely...
+				b.Run("all-duplicates", func(b *testing.B) {
+					expected := [][]interface{}{{}, secondA}
+					if firstLength > secondLength {
+						expected[0] = append(expected[0], firstA[secondLength*2:]...)
+					}
+					benchTrimDuplicates(b, expected, firstA, secondA)
+				})
+
+				// First entry is the same.
+				b.Run("start-duplicate", func(b *testing.B) {
+					first := []interface{}{"x", 1}
+					first = append(first, firstA...)
+					second := []interface{}{"x", 1}
+					second = append(second, secondB...)
+					expected := [][]interface{}{firstA, second}
+					benchTrimDuplicates(b, expected, first, second)
+				})
+
+				// Last entry is the same.
+				b.Run("end-duplicate", func(b *testing.B) {
+					first := firstA[:]
+					first = append(first, "x", 1)
+					second := secondB[:]
+					second = append(second, "x", 1)
+					expected := [][]interface{}{firstA, second}
+					benchTrimDuplicates(b, expected, first, second)
+				})
+			})
+		}
+	}
+}
+
+func makeKV(prefix string, length int) []interface{} {
+	if length == 0 {
+		return []interface{}{}
+	}
+	kv := make([]interface{}, 0, length*2)
+	for i := 0; i < length; i++ {
+		kv = append(kv, fmt.Sprintf("%s-%d", prefix, i), i)
+	}
+	return kv
+}
+
+func benchTrimDuplicates(b *testing.B, expected interface{}, first, second []interface{}) {
+	actual := serialize.TrimDuplicates(first, second)
+	expectEqual(b, "trimmed key/value pairs", expected, actual)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		serialize.TrimDuplicates(first, second)
+	}
+}
+
+func expectEqual(tb testing.TB, what string, expected, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		tb.Fatalf("Did not get correct %s. Expected:\n    %v\nActual:\n    %v", what, expected, actual)
 	}
 }

--- a/klogr.go
+++ b/klogr.go
@@ -43,11 +43,11 @@ func (l *klogger) Init(info logr.RuntimeInfo) {
 }
 
 func (l klogger) Info(level int, msg string, kvList ...interface{}) {
-	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	merged := serialize.MergeKVs(l.values, kvList)
 	if l.prefix != "" {
 		msg = l.prefix + ": " + msg
 	}
-	V(Level(level)).InfoSDepth(l.callDepth+1, msg, append(trimmed[0], trimmed[1]...)...)
+	V(Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
 }
 
 func (l klogger) Enabled(level int) bool {
@@ -55,11 +55,11 @@ func (l klogger) Enabled(level int) bool {
 }
 
 func (l klogger) Error(err error, msg string, kvList ...interface{}) {
-	trimmed := serialize.TrimDuplicates(l.values, kvList)
+	merged := serialize.MergeKVs(l.values, kvList)
 	if l.prefix != "" {
 		msg = l.prefix + ": " + msg
 	}
-	ErrorSDepth(l.callDepth+1, err, msg, append(trimmed[0], trimmed[1]...)...)
+	ErrorSDepth(l.callDepth+1, err, msg, merged...)
 }
 
 // WithName returns a new logr.Logger with the specified name appended.  klogr

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -200,7 +200,7 @@ func testOutput(t *testing.T, format string) {
 				expectedOutput = test.expectedKlogOutput
 			}
 			if actual != expectedOutput {
-				t.Errorf("expected %q did not match actual %q", expectedOutput, actual)
+				t.Errorf("Expected:\n%s\nActual:\n%s\n", expectedOutput, actual)
 			}
 		})
 	}

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -41,7 +41,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
-			expectedOutput: ` "msg"="test"  "akey"="avalue"
+			expectedOutput: ` "msg"="test" "akey"="avalue"
 `,
 			expectedKlogOutput: `"test" akey="avalue"
 `,
@@ -50,7 +50,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().V(0).WithName("me"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
-			expectedOutput: `me "msg"="test"  "akey"="avalue"
+			expectedOutput: `me "msg"="test" "akey"="avalue"
 `,
 			expectedKlogOutput: `"me: test" akey="avalue"
 `,
@@ -59,34 +59,34 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().V(0).WithName("hello").WithName("world"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
-			expectedOutput: `hello/world "msg"="test"  "akey"="avalue"
+			expectedOutput: `hello/world "msg"="test" "akey"="avalue"
 `,
 			expectedKlogOutput: `"hello/world: test" akey="avalue"
 `,
 		},
-		"should not print duplicate keys with the same value": {
+		"may print duplicate keys with the same value": {
 			klogr:         new().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
-			expectedOutput: ` "msg"="test"  "akey"="avalue"
+			expectedOutput: ` "msg"="test" "akey"="avalue"
 `,
-			expectedKlogOutput: `"test" akey="avalue"
+			expectedKlogOutput: `"test" akey="avalue" akey="avalue"
 `,
 		},
-		"should only print the last duplicate key when the values are passed to Info": {
+		"may print duplicate keys when the values are passed to Info": {
 			klogr:         new().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
-			expectedOutput: ` "msg"="test"  "akey"="avalue2"
+			expectedOutput: ` "msg"="test" "akey"="avalue2"
 `,
-			expectedKlogOutput: `"test" akey="avalue2"
+			expectedKlogOutput: `"test" akey="avalue" akey="avalue2"
 `,
 		},
 		"should only print the duplicate key that is passed to Info if one was passed to the logger": {
 			klogr:         new().WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue"},
-			expectedOutput: ` "msg"="test"  "akey"="avalue"
+			expectedOutput: ` "msg"="test" "akey"="avalue"
 `,
 			expectedKlogOutput: `"test" akey="avalue"
 `,
@@ -95,7 +95,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().WithValues("akey9", "avalue9", "akey8", "avalue8", "akey1", "avalue1"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey5", "avalue5", "akey4", "avalue4"},
-			expectedOutput: ` "msg"="test" "akey1"="avalue1" "akey8"="avalue8" "akey9"="avalue9" "akey4"="avalue4" "akey5"="avalue5"
+			expectedOutput: ` "msg"="test" "akey1"="avalue1" "akey4"="avalue4" "akey5"="avalue5" "akey8"="avalue8" "akey9"="avalue9"
 `,
 			expectedKlogOutput: `"test" akey9="avalue9" akey8="avalue8" akey1="avalue1" akey5="avalue5" akey4="avalue4"
 `,
@@ -104,7 +104,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().WithValues("akey", "avalue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue2"},
-			expectedOutput: ` "msg"="test"  "akey"="avalue2"
+			expectedOutput: ` "msg"="test" "akey"="avalue2"
 `,
 			expectedKlogOutput: `"test" akey="avalue2"
 `,
@@ -113,7 +113,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new(),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: ` "msg"="test"  "akey"="avalue" "akey2"="(MISSING)"
+			expectedOutput: ` "msg"="test" "akey"="avalue" "akey2"="(MISSING)"
 `,
 			expectedKlogOutput: `"test" akey="avalue" akey2="(MISSING)"
 `,
@@ -122,7 +122,8 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().WithValues("keyWithoutValue"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: ` "msg"="test" "keyWithoutValue"="(MISSING)" "akey"="avalue" "akey2"="(MISSING)"
+			// klogr format sorts all key/value pairs.
+			expectedOutput: ` "msg"="test" "akey"="avalue" "akey2"="(MISSING)" "keyWithoutValue"="(MISSING)"
 `,
 			expectedKlogOutput: `"test" keyWithoutValue="(MISSING)" akey="avalue" akey2="(MISSING)"
 `,
@@ -131,7 +132,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new(),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "<&>"},
-			expectedOutput: ` "msg"="test"  "akey"="<&>"
+			expectedOutput: ` "msg"="test" "akey"="<&>"
 `,
 			expectedKlogOutput: `"test" akey="<&>"
 `,
@@ -140,7 +141,8 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().WithValues("basekey1", "basevar1", "basekey2"),
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: ` "msg"="test" "basekey1"="basevar1" "basekey2"="(MISSING)" "akey"="avalue" "akey2"="(MISSING)"
+			// klogr format sorts all key/value pairs.
+			expectedOutput: ` "msg"="test" "akey"="avalue" "akey2"="(MISSING)" "basekey1"="basevar1" "basekey2"="(MISSING)"
 `,
 			expectedKlogOutput: `"test" basekey1="basevar1" basekey2="(MISSING)" akey="avalue" akey2="(MISSING)"
 `,
@@ -149,7 +151,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"err", errors.New("whoops")},
-			expectedOutput: ` "msg"="test"  "err"="whoops"
+			expectedOutput: ` "msg"="test" "err"="whoops"
 `,
 			expectedKlogOutput: `"test" err="whoops"
 `,
@@ -158,7 +160,7 @@ func testOutput(t *testing.T, format string) {
 			klogr:         new().V(0),
 			text:          "test",
 			keysAndValues: []interface{}{"err", &customErrorJSON{"whoops"}},
-			expectedOutput: ` "msg"="test"  "err"="WHOOPS"
+			expectedOutput: ` "msg"="test" "err"="WHOOPS"
 `,
 			expectedKlogOutput: `"test" err="whoops"
 `,
@@ -168,9 +170,9 @@ func testOutput(t *testing.T, format string) {
 			text:  "test",
 			err:   errors.New("whoops"),
 			// The message is printed to three different log files (info, warning, error), so we see it three times in our output buffer.
-			expectedOutput: ` "msg"="test" "error"="whoops"  
- "msg"="test" "error"="whoops"  
- "msg"="test" "error"="whoops"  
+			expectedOutput: ` "msg"="test" "error"="whoops" 
+ "msg"="test" "error"="whoops" 
+ "msg"="test" "error"="whoops" 
 `,
 			expectedKlogOutput: `"test" err="whoops"
 "test" err="whoops"

--- a/ktesting/testinglogger.go
+++ b/ktesting/testinglogger.go
@@ -81,9 +81,8 @@ func (l *tlogger) GetCallStackHelper() func() {
 func (l *tlogger) Info(level int, msg string, kvList ...interface{}) {
 	l.t.Helper()
 	buffer := &bytes.Buffer{}
-	trimmed := serialize.TrimDuplicates(l.values, kvList)
-	serialize.KVListFormat(buffer, trimmed[0]...)
-	serialize.KVListFormat(buffer, trimmed[1]...)
+	merged := serialize.MergeKVs(l.values, kvList)
+	serialize.KVListFormat(buffer, merged...)
 	l.log("INFO", msg, buffer)
 }
 
@@ -97,9 +96,8 @@ func (l *tlogger) Error(err error, msg string, kvList ...interface{}) {
 	if err != nil {
 		serialize.KVListFormat(buffer, "err", err)
 	}
-	trimmed := serialize.TrimDuplicates(l.values, kvList)
-	serialize.KVListFormat(buffer, trimmed[0]...)
-	serialize.KVListFormat(buffer, trimmed[1]...)
+	merged := serialize.MergeKVs(l.values, kvList)
+	serialize.KVListFormat(buffer, merged...)
 	l.log("ERROR", msg, buffer)
 }
 

--- a/ktesting/testinglogger_test.go
+++ b/ktesting/testinglogger_test.go
@@ -118,7 +118,7 @@ func TestInfo(t *testing.T) {
 
 			actual := buffer.String()
 			if actual != test.expectedOutput {
-				t.Errorf("expected %q did not match actual %q", test.expectedOutput, actual)
+				t.Errorf("Expected:\n%sActual:\n%s\n", test.expectedOutput, actual)
 			}
 		})
 	}

--- a/ktesting/testinglogger_test.go
+++ b/ktesting/testinglogger_test.go
@@ -46,13 +46,13 @@ func TestInfo(t *testing.T) {
 		"should not print duplicate keys with the same value": {
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue"},
-			expectedOutput: `INFO test akey="avalue"
+			expectedOutput: `INFO test akey="avalue" akey="avalue"
 `,
 		},
 		"should only print the last duplicate key when the values are passed to Info": {
 			text:          "test",
 			keysAndValues: []interface{}{"akey", "avalue", "akey", "avalue2"},
-			expectedOutput: `INFO test akey="avalue2"
+			expectedOutput: `INFO test akey="avalue" akey="avalue2"
 `,
 		},
 		"should only print the duplicate key that is passed to Info if one was passed to the logger": {

--- a/test/output.go
+++ b/test/output.go
@@ -212,16 +212,12 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 			expectedOutput: `I output.go:<LINE>] "test"
 `,
 		},
-		// TODO: unify behavior of loggers.
-		// klog doesn't deduplicate, klogr and textlogger do. We can ensure via static code analysis
-		// that this doesn't occur, so we shouldn't pay the runtime overhead for deduplication here
-		// and remove that from klogr and textlogger (https://github.com/kubernetes/klog/issues/286).
-		// 		"print duplicate keys in arguments": {
-		// 			text:   "test",
-		// 			values: []interface{}{"akey", "avalue", "akey", "avalue2"},
-		// 			expectedOutput: `I output.go:<LINE>] "test" akey="avalue" akey="avalue2"
-		// `,
-		// 		},
+		"print duplicate keys in arguments": {
+			text:   "test",
+			values: []interface{}{"akey", "avalue", "akey", "avalue2"},
+			expectedOutput: `I output.go:<LINE>] "test" akey="avalue" akey="avalue2"
+`,
+		},
 		"preserve order of key/value pairs": {
 			withValues: []interface{}{"akey9", "avalue9", "akey8", "avalue8", "akey1", "avalue1"},
 			text:       "test",

--- a/test/zapr.go
+++ b/test/zapr.go
@@ -37,6 +37,10 @@ func ZaprOutputMappingDirect() map[string]string {
 `: `{"caller":"test/output.go:<LINE>","msg":"helper","v":0,"akey":"avalue"}
 `,
 
+		`I output.go:<LINE>] "test" akey="avalue" akey="avalue2"
+`: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"akey":"avalue","akey":"avalue2"}
+`,
+
 		`I output.go:<LINE>] "hello/world: test" akey="avalue"
 `: `{"logger":"hello.world","caller":"test/output.go:<LINE>","msg":"test","v":0,"akey":"avalue"}
 `,

--- a/textlogger/textlogger.go
+++ b/textlogger/textlogger.go
@@ -132,9 +132,8 @@ func (l *tlogger) print(err error, s severity.Severity, msg string, kvList []int
 	if err != nil {
 		serialize.KVListFormat(&b.Buffer, "err", err)
 	}
-	trimmed := serialize.TrimDuplicates(l.values, kvList)
-	serialize.KVListFormat(&b.Buffer, trimmed[0]...)
-	serialize.KVListFormat(&b.Buffer, trimmed[1]...)
+	merged := serialize.MergeKVs(l.values, kvList)
+	serialize.KVListFormat(&b.Buffer, merged...)
 	if b.Len() == 0 || b.Bytes()[b.Len()-1] != '\n' {
 		b.WriteByte('\n')
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Better performance:

```
name                                   old time/op    new time/op    delta
TrimDuplicates/0x0/no-duplicates-36       177ns ± 3%       2ns ± 0%   -98.76%  (p=0.008 n=5+5)
...
TrimDuplicates/9x9/end-duplicate-36      14.1µs ± 1%     3.0µs ± 1%   -78.39%  (p=0.008 n=5+5)

name                                   old alloc/op   new alloc/op   delta
TrimDuplicates/0x0/no-duplicates-36       48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
...
TrimDuplicates/9x9/no-duplicates-36      4.35kB ± 0%    0.90kB ± 0%   -79.42%  (p=0.008 n=5+5)
TrimDuplicates/9x9/all-duplicates-36     2.03kB ± 0%    0.90kB ± 0%   -55.91%  (p=0.008 n=5+5)
TrimDuplicates/9x9/start-duplicate-36    4.71kB ± 0%    0.96kB ± 0%   -79.56%  (p=0.008 n=5+5)
TrimDuplicates/9x9/end-duplicate-36      4.71kB ± 0%    0.96kB ± 0%      ~     (p=0.079 n=4+5)

name                                   old allocs/op  new allocs/op  delta
TrimDuplicates/0x0/no-duplicates-36        1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
...
TrimDuplicates/9x9/end-duplicate-36        39.0 ± 0%       2.0 ± 0%   -94.87%  (p=0.008 n=5+5)
```


**Which issue(s) this PR fixes**:
Related-to #286

**Special notes for your reviewer**:

The new implementation is simpler and handles some cases differently than before. See commit messages for details.

#286 does not get closed by this only because there is some work left for static code analysis.

**Release note**:
```release-note
Handling of key/value pairs is faster. To achieve this, duplicate keys only get removed when they occur in the WithValues key/value pairs and the log call parameters, but not when the parameters of a call like WithValues of InfoS already contain duplicates. That needs to be prevented during code review. Static code analysis with a future release of logcheck will calso catch this.
```
