### PR TITLE
support logr.Marshaler

### DIFF
--- a/internal/serialize/keyvalues.go
+++ b/internal/serialize/keyvalues.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+
+	"github.com/go-logr/logr"
 )
 
 // WithValues implements LogSink.WithValues. The old key/value pairs are
@@ -131,6 +133,24 @@ func KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
 			writeStringValue(b, true, v)
 		case error:
 			writeStringValue(b, true, ErrorToString(v))
+		case logr.Marshaler:
+			value := MarshalerToValue(v)
+			// A marshaler that returns a string is useful for
+			// delayed formatting of complex values. We treat this
+			// case like a normal string. This is useful for
+			// multi-line support.
+			//
+			// We could do this by recursively formatting a value,
+			// but that comes with the risk of infinite recursion
+			// if a marshaler returns itself. Instead we call it
+			// only once and rely on it returning the intended
+			// value directly.
+			switch value := value.(type) {
+			case string:
+				writeStringValue(b, true, value)
+			default:
+				writeStringValue(b, false, fmt.Sprintf("%+v", v))
+			}
 		case []byte:
 			// In https://github.com/kubernetes/klog/pull/237 it was decided
 			// to format byte slices with "%+q". The advantages of that are:
@@ -160,6 +180,18 @@ func StringerToString(s fmt.Stringer) (ret string) {
 		}
 	}()
 	ret = s.String()
+	return
+}
+
+// MarshalerToValue invokes a marshaler and catches
+// panics.
+func MarshalerToValue(m logr.Marshaler) (ret interface{}) {
+	defer func() {
+		if err := recover(); err != nil {
+			ret = fmt.Sprintf("<panic: %s>", err)
+		}
+	}()
+	ret = m.MarshalLog()
 	return
 }
 

--- a/test/output.go
+++ b/test/output.go
@@ -321,7 +321,13 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 		"MarshalLog() that panics": {
 			text:   "marshaler panic",
 			values: []interface{}{"obj", faultyMarshaler{}},
-			expectedOutput: `I output.go:<LINE>] "marshaler panic" obj={}
+			expectedOutput: `I output.go:<LINE>] "marshaler panic" obj="<panic: fake MarshalLog panic>"
+`,
+		},
+		"MarshalLog() that returns itself": {
+			text:   "marshaler recursion",
+			values: []interface{}{"obj", recursiveMarshaler{}},
+			expectedOutput: `I output.go:<LINE>] "marshaler recursion" obj={}
 `,
 		},
 	}
@@ -764,6 +770,15 @@ func (f faultyMarshaler) MarshalLog() interface{} {
 }
 
 var _ logr.Marshaler = faultyMarshaler{}
+
+type recursiveMarshaler struct{}
+
+// MarshalLog returns itself, which could cause the logger to recurse infinitely.
+func (r recursiveMarshaler) MarshalLog() interface{} {
+	return r
+}
+
+var _ logr.Marshaler = recursiveMarshaler{}
 
 type faultyError struct{}
 

--- a/test/zapr.go
+++ b/test/zapr.go
@@ -137,8 +137,12 @@ I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
 `: `{"caller":"test/output.go:<LINE>","msg":"error panic","errError":"PANIC=fake Error panic"}
 `,
 
-		`I output.go:<LINE>] "marshaler panic" obj={}
+		`I output.go:<LINE>] "marshaler panic" obj="<panic: fake MarshalLog panic>"
 `: `{"caller":"test/output.go:<LINE>","msg":"marshaler panic","v":0,"objError":"PANIC=fake MarshalLog panic"}
+`,
+
+		`I output.go:<LINE>] "marshaler recursion" obj={}
+`: `{"caller":"test/output.go:<LINE>","msg":"marshaler recursion","v":0,"obj":{}}
 `,
 
 		// klog.Info


### PR DESCRIPTION
**What this PR does / why we need it**:

A type that implements only logr.Marshaler but not fmt.Stringer is useful for
delayed formatting. It is not required to return a struct. A plain string may
also be useful.

klog now supports such types by invoking MarshalLog once and then printing the
value as string (including multi-line support) if that is the result or with
the default "%+v".

**Special notes for your reviewer**:

See discussion in https://github.com/kubernetes/klog/pull/322#issuecomment-1112541499

**Release note**:
```release-note
klog now supports logr.Marshaler values by invoking MarshalLog once and then printing the
value as string (including multi-line support) if that is the result or with
the default "%+v". This is useful for custom types which delay expensive formatting until the
result is really needed.
```