### PR TITLE
GitHub: use apidiff with more recent Go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.18
       - name: Add GOBIN to PATH
         run: echo "PATH=$(go env GOPATH)/bin:$PATH" >>$GITHUB_ENV
       - name: Install dependencies


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes:

```
Error: ../../../go/src/golang.org/x/exp/apidiff/correspondence.go:129:8: undefined: types.TypeParam
```

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._
```release-note
NONE
```

/assign @dims 