### PR TITLE
GIT-331: fix shadowing key from the kv pair

### DIFF
--- a/internal/serialize/keyvalues.go
+++ b/internal/serialize/keyvalues.go
@@ -109,10 +109,10 @@ func KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
 		// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
 		// for the sake of performance. Keys with spaces,
 		// special characters, etc. will break parsing.
-		if k, ok := k.(string); ok {
+		if sK, ok := k.(string); ok {
 			// Avoid one allocation when the key is a string, which
 			// normally it should be.
-			b.WriteString(k)
+			b.WriteString(sK)
 		} else {
 			b.WriteString(fmt.Sprintf("%s", k))
 		}

--- a/internal/serialize/keyvalues_test.go
+++ b/internal/serialize/keyvalues_test.go
@@ -140,6 +140,18 @@ No whitespace.`,
 			keysValues: []interface{}{"point-1", point{100, 200}, "point-2", emptyPoint},
 			want:       " point-1=\"x=100, y=200\" point-2=\"<panic: value method k8s.io/klog/v2/internal/serialize_test.point.String called using nil *point pointer>\"",
 		},
+		{
+			keysValues: []interface{}{struct{ key string }{key: "k1"}, "value"},
+			want:       " {k1}=\"value\"",
+		},
+		{
+			keysValues: []interface{}{1, "test"},
+			want:       " %!s(int=1)=\"test\"",
+		},
+		{
+			keysValues: []interface{}{map[string]string{"k": "key"}, "value"},
+			want:       " map[k:key]=\"value\"",
+		},
 	}
 
 	for _, d := range testKVList {


### PR DESCRIPTION
**What this PR does / why we need it**:
While trying to take a stab at #275 I noticed that there is a lingering issue in the `KVListFormat` function in terms of how it processes the keys 

https://github.com/kubernetes/klog/blob/9c48b7d0ba16c13eb24c2311f591a69175f5cb86/internal/serialize/keyvalues.go#L112-L118

In case if the `key` passed to the `KVListFormat` is not of string type, this ends up consuming the key and only printing the value. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #331

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
Non string keys are displayed as string formatted keys
```