### PR TITLE
GIT-275: add tests for int and struct keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15, 1.16, 1.17]
+        go-version: [1.15, 1.16, 1.17, 1.18]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/examples/benchmarks/benchmarks_test.go
+++ b/examples/benchmarks/benchmarks_test.go
@@ -91,6 +91,33 @@ func BenchmarkOutput(b *testing.B) {
 		"fail-verbosity-check": func(value interface{}) {
 			klog.V(verbosityThreshold+1).InfoS("test", "key", value)
 		},
+		"non-standard-int-key-check": func(value interface{}) {
+			klog.InfoS("test", 1, value)
+		},
+		"non-standard-struct-key-check": func(value interface{}) {
+			klog.InfoS("test", struct{ key string }{"test"}, value)
+		},
+		"non-standard-map-key-check": func(value interface{}) {
+			klog.InfoS("test", map[string]bool{"key": true}, value)
+		},
+		"pass-verbosity-non-standard-int-key-check": func(value interface{}) {
+			klog.V(verbosityThreshold).InfoS("test", 1, value)
+		},
+		"pass-verbosity-non-standard-struct-key-check": func(value interface{}) {
+			klog.V(verbosityThreshold).InfoS("test", struct{ key string }{"test"}, value)
+		},
+		"pass-verbosity-non-standard-map-key-check": func(value interface{}) {
+			klog.V(verbosityThreshold).InfoS("test", map[string]bool{"key": true}, value)
+		},
+		"fail-verbosity-non-standard-int-key-check": func(value interface{}) {
+			klog.V(verbosityThreshold+1).InfoS("test", 1, value)
+		},
+		"fail-verbosity-non-standard-struct-key-check": func(value interface{}) {
+			klog.V(verbosityThreshold+1).InfoS("test", struct{ key string }{"test"}, value)
+		},
+		"fail-verbosity-non-standard-map-key-check": func(value interface{}) {
+			klog.V(verbosityThreshold+1).InfoS("test", map[string]bool{"key": true}, value)
+		},
 	}
 
 	for name, config := range configs {

--- a/examples/output_test/output_test.go
+++ b/examples/output_test/output_test.go
@@ -63,7 +63,7 @@ func TestTextloggerOutput(t *testing.T) {
 	})
 }
 
-// TestTextloggerOutput tests the zapr, directly and as backend.
+// TestZaprOutput tests the zapr, directly and as backend.
 func TestZaprOutput(t *testing.T) {
 	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
 		return newZaprLogger(out, v)
@@ -122,6 +122,18 @@ func TestKlogrStackZapr(t *testing.T) {
 		`I output.go:<LINE>] "both odd" basekey1="basevar1" basekey2="(MISSING)" akey="avalue" akey2="(MISSING)"
 `: `{"caller":"test/output.go:<LINE>","msg":"both odd","v":0,"basekey1":"basevar1","basekey2":"(MISSING)","akey":"avalue","akey2":"(MISSING)"}
 `,
+		`I output.go:<LINE>] "integer keys" %!s(int=1)="value" %!s(int=2)="value2" akey="avalue" akey2="(MISSING)"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":1}
+{"caller":"test/output.go:<LINE>","msg":"integer keys","v":0}
+`,
+		`I output.go:<LINE>] "struct keys" {name}="value" test="other value" key="val"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{}}
+{"caller":"test/output.go:<LINE>","msg":"struct keys","v":0}
+`,
+		`I output.go:<LINE>] "map keys" map[test:%!s(bool=true)]="test"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{"test":true}}
+{"caller":"test/output.go:<LINE>","msg":"map keys","v":0}
+`,
 	} {
 		mapping[key] = value
 	}
@@ -172,6 +184,18 @@ func TestKlogrInternalStackZapr(t *testing.T) {
 
 		`I output.go:<LINE>] "both odd" basekey1="basevar1" basekey2="(MISSING)" akey="avalue" akey2="(MISSING)"
 `: `{"caller":"test/output.go:<LINE>","msg":"both odd","v":0,"basekey1":"basevar1","basekey2":"(MISSING)","akey":"avalue","akey2":"(MISSING)"}
+`,
+		`I output.go:<LINE>] "integer keys" %!s(int=1)="value" %!s(int=2)="value2" akey="avalue" akey2="(MISSING)"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":1}
+{"caller":"test/output.go:<LINE>","msg":"integer keys","v":0}
+`,
+		`I output.go:<LINE>] "struct keys" {name}="value" test="other value" key="val"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{}}
+{"caller":"test/output.go:<LINE>","msg":"struct keys","v":0}
+`,
+		`I output.go:<LINE>] "map keys" map[test:%!s(bool=true)]="test"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{"test":true}}
+{"caller":"test/output.go:<LINE>","msg":"map keys","v":0}
 `,
 	} {
 		mapping[key] = value

--- a/test/output.go
+++ b/test/output.go
@@ -367,6 +367,27 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 			expectedOutput: `I output.go:<LINE>] "marshaler recursion" obj={}
 `,
 		},
+		"handle integer keys": {
+			withValues: []interface{}{1, "value", 2, "value2"},
+			text:       "integer keys",
+			values:     []interface{}{"akey", "avalue", "akey2"},
+			expectedOutput: `I output.go:<LINE>] "integer keys" %!s(int=1)="value" %!s(int=2)="value2" akey="avalue" akey2="(MISSING)"
+`,
+		},
+		"struct keys": {
+			withValues: []interface{}{struct{ name string }{"name"}, "value", "test", "other value"},
+			text:       "struct keys",
+			values:     []interface{}{"key", "val"},
+			expectedOutput: `I output.go:<LINE>] "struct keys" {name}="value" test="other value" key="val"
+`,
+		},
+		"map keys": {
+			withValues: []interface{}{},
+			text:       "map keys",
+			values:     []interface{}{map[string]bool{"test": true}, "test"},
+			expectedOutput: `I output.go:<LINE>] "map keys" map[test:%!s(bool=true)]="test"
+`,
+		},
 	}
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {

--- a/test/zapr.go
+++ b/test/zapr.go
@@ -218,6 +218,21 @@ I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
 		`I output.go:<LINE>] "hello" what="one world"
 `: `{"caller":"test/output.go:<LINE>","msg":"hello","v":1,"what":"one world"}
 `,
+
+		`I output.go:<LINE>] "integer keys" %!s(int=1)="value" %!s(int=2)="value2" akey="avalue" akey2="(MISSING)"
+`: `{"caller":"test/output.go:<WITH-VALUES>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":1}
+{"caller":"test/output.go:<LINE>","msg":"odd number of arguments passed as key-value pairs for logging","ignored key":"akey2"}
+{"caller":"test/output.go:<LINE>","msg":"integer keys","v":0,"akey":"avalue"}
+`,
+
+		`I output.go:<LINE>] "struct keys" {name}="value" test="other value" key="val"
+`: `{"caller":"test/output.go:<WITH-VALUES>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{}}
+{"caller":"test/output.go:<LINE>","msg":"struct keys","v":0,"key":"val"}
+`,
+		`I output.go:<LINE>] "map keys" map[test:%!s(bool=true)]="test"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{"test":true}}
+{"caller":"test/output.go:<LINE>","msg":"map keys","v":0}
+`,
 	}
 }
 
@@ -291,6 +306,18 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 {"caller":"test/output.go:<LINE>","msg":"test","v":0,"firstKey":1,"secondKey":2}
 {"caller":"test/output.go:<LINE>","msg":"test","v":0,"firstKey":1}
 {"caller":"test/output.go:<LINE>","msg":"test","v":0,"firstKey":1,"secondKey":3}
+`,
+		`I output.go:<LINE>] "integer keys" %!s(int=1)="value" %!s(int=2)="value2" akey="avalue" akey2="(MISSING)"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":1}
+{"caller":"test/output.go:<LINE>","msg":"integer keys","v":0}
+`,
+		`I output.go:<LINE>] "struct keys" {name}="value" test="other value" key="val"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{}}
+{"caller":"test/output.go:<LINE>","msg":"struct keys","v":0}
+`,
+		`I output.go:<LINE>] "map keys" map[test:%!s(bool=true)]="test"
+`: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{"test":true}}
+{"caller":"test/output.go:<LINE>","msg":"map keys","v":0}
 `,
 	} {
 		mapping[key] = value


### PR DESCRIPTION
**What this PR does / why we need it**:
Add additional Test coverage and benchmarking for the un-usual non standard string keys when used with `WithValues` or online as `key/value` pairs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #275 

**Special notes for your reviewer**:

This just adds tests and benchmarks

**Release note**:
```release-note
NA
```

**TODO**

- [x] Add test for map keys
- [x] Add benchmark items