### PR TITLE
Added support for external setting of log verbosity through the klog. Addresses issue #336

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -437,6 +437,10 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
 }
 
+func SetVerbosity(level Level) {
+	logging.setVerbosity(level)
+}
+
 // Flush flushes all pending log I/O.
 func Flush() {
 	logging.lockAndFlushAll()
@@ -550,6 +554,10 @@ type loggingT struct {
 }
 
 var logging loggingT
+
+func (l *loggingT) setVerbosity(level Level) {
+	l.setVState(level, nil, false)
+}
 
 // setVState sets a consistent state for V logging.
 // l.mu is held.

--- a/klog_test.go
+++ b/klog_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	stdLog "log"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1156,6 +1157,99 @@ func TestSetVState(t *testing.T) {
 
 	if want.verbosity != target.verbosity || !compareModuleSpec(want.vmodule, target.vmodule) || want.filterLength != target.filterLength {
 		t.Errorf("setVState method doesn't configure loggingT values' verbosity, vmodule or filterLength:\nwant:\n\tverbosity:\t%v\n\tvmodule:\t%v\n\tfilterLength:\t%v\ngot:\n\tverbosity:\t%v\n\tvmodule:\t%v\n\tfilterLength:\t%v", want.verbosity, want.vmodule, want.filterLength, target.verbosity, target.vmodule, target.filterLength)
+	}
+}
+
+func Test_loggingT_SetVerbosity(t *testing.T) {
+
+	type args struct {
+		level Level
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantLevel Level
+	}{
+		{
+			name: "TestLevel1",
+			args: args{
+				level: 1,
+			},
+			wantLevel: 1,
+		},
+		{
+			name: "TestLevel2",
+			args: args{
+				level: 2,
+			},
+			wantLevel: 2,
+		},
+		{
+			name: "TestLevel3",
+			args: args{
+				level: 3,
+			},
+			wantLevel: 3,
+		},
+		{
+			name: "TestLevel4",
+			args: args{
+				level: 4,
+			},
+			wantLevel: 4,
+		},
+		{
+			name: "TestLevel5",
+			args: args{
+				level: 5,
+			},
+			wantLevel: 5,
+		},
+		{
+			name: "TestLevel6",
+			args: args{
+				level: 6,
+			},
+			wantLevel: 6,
+		},
+		{
+			name: "TestLevel7",
+			args: args{
+				level: 7,
+			},
+			wantLevel: 7,
+		},
+		{
+			name: "TestLevel8",
+			args: args{
+				level: 8,
+			},
+			wantLevel: 8,
+		},
+		{
+			name: "TestLevel9",
+			args: args{
+				level: 9,
+			},
+			wantLevel: 9,
+		},
+		{
+			name: "TestLevel10",
+			args: args{
+				level: 10,
+			},
+			wantLevel: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := createTestValueOfLoggingT()
+			l.verbosity = Level(rand.Intn(9) + 1) // Randomize the entry value
+			l.setVerbosity(tt.args.level)
+			if l.verbosity != tt.wantLevel {
+				t.Errorf("loggingT.SetVerbosty() = %v, want %v", l.verbosity, tt.wantLevel)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR proposes API changes to allow external configuration of specifically logging verbosity outside of simply using flags.

This addresses #336 .

I managed to implement this in a few minutes and figured I would open a PR for the sake of openness. Let me know if there is still apprehension on making an API change like this one.

Signed-off by: Kendall Tauser <kttpsy@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```