### PR TITLE
contextual logging: enable by default again

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -549,7 +549,11 @@ type loggingT struct {
 	vmap map[uintptr]Level
 }
 
-var logging loggingT
+var logging = loggingT{
+	settings: settings{
+		contextualLoggingEnabled: true,
+	},
+}
 
 // setVState sets a consistent state for V logging.
 // l.mu is held.

--- a/ktesting/contextual_test.go
+++ b/ktesting/contextual_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ktesting_test
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func TestContextual(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	doSomething(ctx)
+
+	// When contextual logging is disabled, the output goes to klog
+	// instead of the testing logger.
+	state := klog.CaptureState()
+	defer state.Restore()
+	klog.EnableContextualLogging(false)
+	doSomething(ctx)
+
+	testingLogger, ok := logger.GetSink().(ktesting.Underlier)
+	if !ok {
+		t.Fatal("Should have had a ktesting LogSink!?")
+	}
+
+	actual := testingLogger.GetBuffer().String()
+	expected := `INFO hello world
+INFO foo: hello also from me
+`
+	if actual != expected {
+		t.Errorf("mismatch in captured output, expected:\n%s\ngot:\n%s\n", expected, actual)
+	}
+}
+
+func doSomething(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger.Info("hello world")
+
+	logger = logger.WithName("foo")
+	ctx = klog.NewContext(ctx, logger)
+	doSomeMore(ctx)
+}
+
+func doSomeMore(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger.Info("hello also from me")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Commit 3c90bf9a79bf6ed7c82fa8cafeaf1681c8555255 accidentally changed the
default for contextual logging from "enabled" to "disabled". The intention
always was and still is to make the new API do something useful by default and
only be more cautious in key Kubernetes binaries which have a feature gate.

**Special notes for your reviewer**:

Now there are unit tests...

**Release note**:
```release-note
Contextual logging was unintentionally disabled by default.
```
