### PR TITLE
Add fully qualified resource reference type

### DIFF
--- a/internal/serialize/keyvalues_test.go
+++ b/internal/serialize/keyvalues_test.go
@@ -166,6 +166,27 @@ No whitespace.`,
 			want: " pods=[kube-system/kube-dns mi-conf]",
 		},
 		{
+			keysValues: []interface{}{"deployment", klog.ResourceRef{Group: "apps", Kind: "deployment", Version: "v1", Name: "test-name", Namespace: "test-ns"}, "status", "ready"},
+			want:       " deployment=\"apps/v1/deployment/test-ns/test-name\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"pod", klog.ResourceRef{Kind: "pod", Version: "v1", Name: "test-name", Namespace: "test-ns"}, "status", "ready"},
+			want:       " pod=\"v1/pod/test-ns/test-name\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"object", klog.ResourceRef{Group: "test-group", Kind: "test-kind", Version: "v1"}, "status", "ready"},
+			want:       " object=\"test-group/v1/test-kind\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"object", klog.ResourceRef{Name: "test-name", Namespace: "test-ns"}, "status", "ready"},
+			want:       " object=\"test-ns/test-name\" status=\"ready\"",
+		},
+		{
+			keysValues: []interface{}{"object", klog.ResourceRef{Kind: "test-kind", Name: "test-name", Namespace: "test-ns"}, "status", "ready"},
+			want:       " object=\"test-kind/test-ns/test-name\" status=\"ready\"",
+		},
+
+		{
 			keysValues: []interface{}{"point-1", point{100, 200}, "point-2", emptyPoint},
 			want:       " point-1=\"x=100, y=200\" point-2=\"<panic: value method k8s.io/klog/v2/internal/serialize_test.point.String called using nil *point pointer>\"",
 		},

--- a/k8s_references.go
+++ b/k8s_references.go
@@ -158,7 +158,7 @@ func (ks kobjSlice) process() ([]interface{}, error) {
 	return objectRefs, nil
 }
 
-// ResourceRef is a full Kubernetes resource reference composed of Group, Version, Kind, Namespace and Name.
+// ResourceRef references a Kubernetes object using Group, Version, Kind, Namespace and Name
 type ResourceRef struct {
 	Group     string `json:"group,omitempty"`
 	Version   string `json:"version,omitempty"`

--- a/k8s_references.go
+++ b/k8s_references.go
@@ -167,20 +167,9 @@ type ResourceRef struct {
 	Name      string `json:"name,omitempty"`
 }
 
-// KResourceRef returns ResourceRef from group, version, kind, namespace and name.
-func KResourceRef(group, version, kind, namespace, name string) ResourceRef {
-	return ResourceRef{
-		Group:     group,
-		Version:   version,
-		Kind:      kind,
-		Namespace: namespace,
-		Name:      name,
-	}
-}
-
-func (l ResourceRef) String() string {
+func (r ResourceRef) String() string {
 	var parts []string
-	for _, s := range []string{l.Group, l.Version, l.Kind, l.Namespace, l.Name} {
+	for _, s := range []string{r.Group, r.Version, r.Kind, r.Namespace, r.Name} {
 		if strings.TrimSpace(s) != "" {
 			parts = append(parts, s)
 		}
@@ -190,7 +179,7 @@ func (l ResourceRef) String() string {
 
 // MarshalLog ensures that loggers with support for structured output will log
 // as a struct by removing the String method via a custom type.
-func (l ResourceRef) MarshalLog() interface{} {
-	type kResourceRefWithoutStringFunc ResourceRef
-	return kResourceRefWithoutStringFunc(l)
+func (r ResourceRef) MarshalLog() interface{} {
+	type resourceRefWithoutStringFunc ResourceRef
+	return resourceRefWithoutStringFunc(r)
 }

--- a/klog_test.go
+++ b/klog_test.go
@@ -966,19 +966,19 @@ func TestResourceRefString(t *testing.T) {
 		{
 			testname:  "with group, version, kind, namespace and name",
 			group:     "test-group",
-			version:   "test-version",
+			version:   "v0.1.0",
 			kind:      "test-kind",
 			namespace: "test-ns",
 			name:      "test-name",
-			want:      "test-group/test-version/test-kind/test-ns/test-name",
+			want:      "test-group/v0.1.0/test-kind/test-ns/test-name",
 		},
 		{
 			testname:  "with group, version, namespace and name",
 			group:     "test-group",
-			version:   "test-version",
+			version:   "v0.1.0",
 			namespace: "test-ns",
 			name:      "test-name",
-			want:      "test-group/test-version/test-ns/test-name",
+			want:      "test-group/v0.1.0/test-ns/test-name",
 		},
 		{
 			testname:  "with group, namespace and name",

--- a/klog_test.go
+++ b/klog_test.go
@@ -953,83 +953,7 @@ func TestKRef(t *testing.T) {
 	}
 }
 
-func TestKResourceRef(t *testing.T) {
-	tests := []struct {
-		testname  string
-		group     string
-		version   string
-		kind      string
-		name      string
-		namespace string
-		want      ResourceRef
-	}{
-		{
-			testname:  "with group, version, kind, namespace and name",
-			name:      "test-name",
-			namespace: "test-ns",
-			group:     "test-group",
-			version:   "test-version",
-			kind:      "test-kind",
-			want: ResourceRef{
-				Group:     "test-group",
-				Version:   "test-version",
-				Kind:      "test-kind",
-				Name:      "test-name",
-				Namespace: "test-ns",
-			},
-		},
-		{
-			testname:  "with group, version, namespace and name",
-			name:      "test-name",
-			namespace: "test-ns",
-			group:     "test-group",
-			version:   "test-version",
-			want: ResourceRef{
-				Group:     "test-group",
-				Version:   "test-version",
-				Name:      "test-name",
-				Namespace: "test-ns",
-			},
-		},
-		{
-			testname:  "with group, namespace and name",
-			name:      "test-name",
-			namespace: "test-ns",
-			group:     "test-group",
-			want: ResourceRef{
-				Group:     "test-group",
-				Name:      "test-name",
-				Namespace: "test-ns",
-			},
-		},
-		{
-			testname:  "with namespace and name",
-			name:      "test-name",
-			namespace: "test-ns",
-			want: ResourceRef{
-				Name:      "test-name",
-				Namespace: "test-ns",
-			},
-		},
-		{
-			testname: "with only name",
-			name:     "test-name",
-			want: ResourceRef{
-				Name: "test-name",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.testname, func(t *testing.T) {
-			if KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name) != tt.want {
-				t.Errorf("expected %v, got %v", tt.want, KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name))
-			}
-		})
-	}
-}
-
-func TestKResourceString(t *testing.T) {
+func TestResourceRefString(t *testing.T) {
 	tests := []struct {
 		testname  string
 		group     string
@@ -1078,8 +1002,9 @@ func TestKResourceString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testname, func(t *testing.T) {
-			if KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name).String() != tt.want {
-				t.Errorf("expected %v, got %v", tt.want, KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name))
+			ref := ResourceRef{tt.group, tt.version, tt.kind, tt.namespace, tt.name}
+			if ref.String() != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, ref.String())
 			}
 		})
 	}

--- a/klog_test.go
+++ b/klog_test.go
@@ -953,6 +953,138 @@ func TestKRef(t *testing.T) {
 	}
 }
 
+func TestKResourceRef(t *testing.T) {
+	tests := []struct {
+		testname  string
+		group     string
+		version   string
+		kind      string
+		name      string
+		namespace string
+		want      ResourceRef
+	}{
+		{
+			testname:  "with group, version, kind, namespace and name",
+			name:      "test-name",
+			namespace: "test-ns",
+			group:     "test-group",
+			version:   "test-version",
+			kind:      "test-kind",
+			want: ResourceRef{
+				Group:     "test-group",
+				Version:   "test-version",
+				Kind:      "test-kind",
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+		},
+		{
+			testname:  "with group, version, namespace and name",
+			name:      "test-name",
+			namespace: "test-ns",
+			group:     "test-group",
+			version:   "test-version",
+			want: ResourceRef{
+				Group:     "test-group",
+				Version:   "test-version",
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+		},
+		{
+			testname:  "with group, namespace and name",
+			name:      "test-name",
+			namespace: "test-ns",
+			group:     "test-group",
+			want: ResourceRef{
+				Group:     "test-group",
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+		},
+		{
+			testname:  "with namespace and name",
+			name:      "test-name",
+			namespace: "test-ns",
+			want: ResourceRef{
+				Name:      "test-name",
+				Namespace: "test-ns",
+			},
+		},
+		{
+			testname: "with only name",
+			name:     "test-name",
+			want: ResourceRef{
+				Name: "test-name",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testname, func(t *testing.T) {
+			if KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name) != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name))
+			}
+		})
+	}
+}
+
+func TestKResourceString(t *testing.T) {
+	tests := []struct {
+		testname  string
+		group     string
+		version   string
+		kind      string
+		name      string
+		namespace string
+		want      string
+	}{
+		{
+			testname:  "with group, version, kind, namespace and name",
+			group:     "test-group",
+			version:   "test-version",
+			kind:      "test-kind",
+			namespace: "test-ns",
+			name:      "test-name",
+			want:      "test-group/test-version/test-kind/test-ns/test-name",
+		},
+		{
+			testname:  "with group, version, namespace and name",
+			group:     "test-group",
+			version:   "test-version",
+			namespace: "test-ns",
+			name:      "test-name",
+			want:      "test-group/test-version/test-ns/test-name",
+		},
+		{
+			testname:  "with group, namespace and name",
+			group:     "test-group",
+			namespace: "test-ns",
+			name:      "test-name",
+			want:      "test-group/test-ns/test-name",
+		},
+		{
+			testname:  "with namespace and name",
+			namespace: "test-ns",
+			name:      "test-name",
+			want:      "test-ns/test-name",
+		},
+		{
+			testname: "with only name",
+			name:     "test-name",
+			want:     "test-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testname, func(t *testing.T) {
+			if KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name).String() != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, KResourceRef(tt.group, tt.version, tt.kind, tt.namespace, tt.name))
+			}
+		})
+	}
+}
+
 // Test that InfoS and InfoSDepth work as advertised.
 func TestInfoS(t *testing.T) {
 	defer CaptureState().Restore()


### PR DESCRIPTION
This PR adds a new type - `ResourceReference` - and a function to use it which allows logging a fully qualified resource reference that allows logging Name, Namespace, Kind, Version and Group for an object.

Fixes #350 


```release-note
New type - `ResourceReference` which allows logging a fully qualified resource reference that allows logging Name, Namespace, Kind, Version and Group for an object.
```