### PR TITLE
RFC: extract values from context on demand

### DIFF
--- a/context_log_sink.go
+++ b/context_log_sink.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+// contextLogSink inherits most of the functionality from some other
+// LogSink. It stores a context and information which key/value pairs from that
+// context are meant to be logged. Then if some log entry really gets emitted,
+// it extracts those values and adds them.
+//
+// This causes little overhead when nothing gets logged (logger not used or
+// entry not enabled).
+type contextLogSink struct {
+	logr.LogSink
+	contextValues
+}
+
+// contextLogSinkDepth is a variant of contextLogSink for LogSinks which
+// implement also CallDepthLogSink.
+type contextLogSinkDepth struct {
+	logr.LogSink
+	logr.CallDepthLogSink
+	contextValues
+	callDepth int
+}
+
+// contextLogSinkDepth is a variant of contextLogSink for LogSinks which
+// implement also CallStackHelperLogSink.
+type contextLogSinkHelper struct {
+	logr.LogSink
+	logr.CallStackHelperLogSink
+	contextValues
+}
+
+func (cls *contextLogSink) Info(level int, msg string, keysAndValues ...interface{}) {
+	keysAndValues = cls.contextValues.append(keysAndValues)
+	cls.LogSink.Info(level, msg, keysAndValues...)
+}
+
+func (cls *contextLogSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	clone := *cls
+	clone.LogSink = clone.LogSink.WithValues(keysAndValues...)
+	return &clone
+}
+
+func (cls *contextLogSinkDepth) Info(level int, msg string, keysAndValues ...interface{}) {
+	keysAndValues = cls.contextValues.append(keysAndValues)
+	logSink := cls.CallDepthLogSink.WithCallDepth(1 + cls.callDepth)
+	logSink.Info(level, msg, keysAndValues...)
+}
+
+func (cls *contextLogSinkDepth) WithCallDepth(depth int) logr.LogSink {
+	clone := *cls
+	clone.callDepth += depth
+	return &clone
+}
+
+func (cls *contextLogSinkDepth) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	clone := *cls
+	clone.LogSink = clone.LogSink.WithValues(keysAndValues...)
+	// This expects the same capabilities for the new LogSink as before.
+	clone.CallDepthLogSink = clone.LogSink.(logr.CallDepthLogSink)
+	return &clone
+}
+
+func (cls *contextLogSinkHelper) Info(level int, msg string, keysAndValues ...interface{}) {
+	keysAndValues = cls.contextValues.append(keysAndValues)
+	helper := cls.CallStackHelperLogSink.GetCallStackHelper()
+	helper()
+	cls.LogSink.Info(level, msg, keysAndValues...)
+}
+
+func (cls *contextLogSinkHelper) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	clone := *cls
+	clone.LogSink = clone.LogSink.WithValues(keysAndValues...)
+	// This expects the same capabilities for the new LogSink as before.
+	clone.CallStackHelperLogSink = clone.LogSink.(logr.CallStackHelperLogSink)
+	return &clone
+}
+
+type contextValues struct {
+	ctx  context.Context
+	keys []ContextKey
+}
+
+func (cv contextValues) append(keysAndValues []interface{}) []interface{} {
+	for _, key := range cv.keys {
+		if value := cv.ctx.Value(key.Key); value != nil {
+			keysAndValues = append(keysAndValues, key.Name, value)
+		}
+	}
+	return keysAndValues
+}
+
+func (cv contextValues) extract() []interface{} {
+	keysAndValues := make([]interface{}, 0, 2*len(cv.keys))
+	for _, key := range cv.keys {
+		if value := cv.ctx.Value(key.Key); value != nil {
+			keysAndValues = append(keysAndValues, key.Name, value)
+		}
+	}
+	return keysAndValues
+}

--- a/internal/benchmarks/contextvalues/contextvalues_test.go
+++ b/internal/benchmarks/contextvalues/contextvalues_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contextvalues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+)
+
+const iterationsPerOp = 100
+
+// 1% of the Info calls are invoked, all of those call the LogSink.
+func BenchmarkNewContext1Percent(b *testing.B) {
+	ctx := klog.NewContext(context.Background(), discardWithV(1))
+	defer func() {
+		expected := int64(iterationsPerOp) / 100 * int64(b.N)
+		if infoCalls != expected {
+			b.Errorf("expected %d calls to Info, got %d", expected, infoCalls)
+		}
+		infoCalls = 0
+	}()
+
+	// Each iteration is expected to do exactly the same thing,
+	// in particular do the same number of allocs.
+	for i := 0; i < b.N; i++ {
+		// Therefore we repeat newContext a certain number of
+		// times. Individual repetitions are allowed to sometimes log
+		// and sometimes not, but the overall execution is the same for
+		// every outer loop iteration.
+		for j := 0; j < iterationsPerOp; j++ {
+			newContext(ctx, j, 100, 0)
+		}
+	}
+}
+
+// 100% of the Info calls are invoked, none of those call the LogSink.
+func BenchmarkNewContext100PercentDisabled(b *testing.B) {
+	ctx := klog.NewContext(context.Background(), discardWithV(1))
+	defer func() {
+		expected := int64(0)
+		if infoCalls != expected {
+			b.Errorf("expected %d calls to Info, got %d", expected, infoCalls)
+		}
+		infoCalls = 0
+	}()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < iterationsPerOp; j++ {
+			newContext(ctx, j, 1, 2)
+		}
+	}
+}
+
+// 100% of the Info calls are invoked, all of those call the LogSink.
+func BenchmarkNewContext100Percent(b *testing.B) {
+	ctx := klog.NewContext(context.Background(), discardWithV(1))
+	defer func() {
+		expected := int64(b.N) * iterationsPerOp
+		if infoCalls != expected {
+			b.Errorf("expected %d calls to Info, got %d", expected, infoCalls)
+		}
+		infoCalls = 0
+	}()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < iterationsPerOp; j++ {
+			newContext(ctx, j, 1, 0)
+		}
+	}
+}
+
+func BenchmarkNewContext1PercentValues(b *testing.B) {
+	initContextValues(b)
+	ctx := klog.NewContext(context.Background(), discardWithV(1))
+	defer func() {
+		expected := int64(iterationsPerOp) / 100 * int64(b.N)
+		if infoCalls != expected {
+			b.Errorf("expected %d calls to Info, got %d", expected, infoCalls)
+		}
+		infoCalls = 0
+	}()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < iterationsPerOp; j++ {
+			newContextValues(ctx, j, 100, 0)
+		}
+	}
+}
+
+func BenchmarkNewContext100PercentDisabledValues(b *testing.B) {
+	initContextValues(b)
+	ctx := klog.NewContext(context.Background(), discardWithV(1))
+	defer func() {
+		expected := int64(0)
+		if infoCalls != expected {
+			b.Errorf("expected %d calls to Info, got %d", expected, infoCalls)
+		}
+		infoCalls = 0
+	}()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < iterationsPerOp; j++ {
+			newContextValues(ctx, j, 1, 2)
+		}
+	}
+}
+
+func BenchmarkNewContext100PercentValues(b *testing.B) {
+	initContextValues(b)
+	ctx := klog.NewContext(context.Background(), discardWithV(1))
+	defer func() {
+		expected := int64(b.N) * iterationsPerOp
+		if infoCalls != expected {
+			b.Errorf("expected %d calls to Info, got %d", expected, infoCalls)
+		}
+		infoCalls = 0
+	}()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < iterationsPerOp; j++ {
+			newContextValues(ctx, j, 1, 0)
+		}
+	}
+}
+
+type contextKey1 struct{}
+type contextKey2 struct{}
+
+func initContextValues(b *testing.B) {
+	state := klog.CaptureState()
+	b.Cleanup(state.Restore)
+	klog.SetFromContextKeys(
+		klog.ContextKey{contextKey1{}, "i"},
+		klog.ContextKey{contextKey2{}, "j"},
+	)
+}
+
+func newContext(ctx context.Context, j, mod, v int) {
+	// This is the currently recommended way of adding a value to a context
+	// and ensuring that all future log calls include it.  Trace IDs might
+	// get handled like this.
+	logger := klog.FromContext(ctx)
+	logger = klog.LoggerWithValues(logger, "i", 1, "j", 2)
+	ctx = context.WithValue(ctx, contextKey1{}, 1)
+	ctx = context.WithValue(ctx, contextKey2{}, 2)
+	ctx = klog.NewContext(ctx, logger)
+	useContext(ctx, j, mod, v)
+}
+
+func newContextValues(ctx context.Context, j, mod, v int) {
+	// This variant only adds to the context. It relies on
+	// klog.FromContextKeys to log them.
+	ctx = context.WithValue(ctx, contextKey1{}, 1)
+	ctx = context.WithValue(ctx, contextKey2{}, 2)
+	useContext(ctx, j, mod, v)
+}
+
+func useContext(ctx context.Context, j, mod, v int) {
+	if j%mod == 0 {
+		logger := klog.FromContext(ctx)
+		logger.V(v).Info("ping", "string", "hello world", "int", 1, "float", 1.0)
+	}
+}
+
+func discardWithV(v int) logr.Logger {
+	logger := logr.New(&discardLogSink{v: v})
+	return logger
+}
+
+var infoCalls int64
+
+// discardLogSink is a LogSink that discards all messages but has
+// a verbosity threshold to compare calls which call Info vs. those
+// that don't.
+type discardLogSink struct {
+	v int
+}
+
+func (l discardLogSink) Init(logr.RuntimeInfo) {
+}
+
+func (l discardLogSink) Enabled(v int) bool {
+	return v <= l.v
+}
+
+func (l discardLogSink) Info(int, string, ...interface{}) {
+	infoCalls++
+}
+
+func (l discardLogSink) Error(error, string, ...interface{}) {
+}
+
+func (l discardLogSink) WithValues(...interface{}) logr.LogSink {
+	return l
+}
+
+func (l discardLogSink) WithName(string) logr.LogSink {
+	return l
+}

--- a/klog.go
+++ b/klog.go
@@ -513,6 +513,10 @@ type settings struct {
 
 	// If set, all output will be filtered through the filter.
 	filter LogFilter
+
+	// fromContextKeys tells FromContext which values from the context are
+	// meant to be logger.
+	fromContextKeys []ContextKey
 }
 
 // deepCopy creates a copy that doesn't share anything with the original


### PR DESCRIPTION
**What this PR does / why we need it**:

Having to add a modified logger to a context when adding some values to the context which are meant to be logged (like trace ID) has two drawbacks:
- the instrumentation code which adds the values to the context must be aware of logging
- modifying the logger incurs a cost, whether some actual log entry then gets emitted or not.

A better approach is to add the values only to the context, then during logging extract them. The solution in this commit does that entirely in klog: it wraps the LogSink from the context or the default in a LogSink which remembers the context and the desired keys, then adds them to the parameters.

Fixes #356

**Special notes for your reviewer**:

Adding to the parameters was chosen instead of using WithValues because it was a bit faster.

With this approach, doing calls with no logging because of the verbosity threshold (100PercentDisabled) and only emitting a log entry for 1% of the iterations (1Percent) becomes considerably cheaper and faster. The case where log entries really get emitted becomes slower, but that is acceptable because actually doing logging is already slow and not necessarily the case that we must optimize for.

```
name                                   time/op
NewContext1Percent-36                  67.8µs ± 4%
NewContext100PercentDisabled-36        86.4µs ± 3%
NewContext100Percent-36                90.7µs ± 2%
NewContext1PercentValues-36            27.0µs ± 2%
NewContext100PercentDisabledValues-36  64.3µs ± 2%
NewContext100PercentValues-36           122µs ± 2%

name                                   alloc/op
NewContext1Percent-36                  23.3kB ± 0%
NewContext100PercentDisabled-36        32.8kB ± 0%
NewContext100Percent-36                32.8kB ± 0%
NewContext1PercentValues-36            10.0kB ± 0%
NewContext100PercentDisabledValues-36  25.6kB ± 0%
NewContext100PercentValues-36          48.0kB ± 0%

name                                   allocs/op
NewContext1Percent-36                     501 ± 0%
NewContext100PercentDisabled-36           600 ± 0%
NewContext100Percent-36                   600 ± 0%
NewContext1PercentValues-36               205 ± 0%
NewContext100PercentDisabledValues-36     400 ± 0%
NewContext100PercentValues-36             700 ± 0%
```

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

TODO:

```release-note
```