### PR TITLE
improve textlogger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint
         run: |
           docker run --rm -v `pwd`:/go/src/k8s.io/klog -w /go/src/k8s.io/klog \
-            golangci/golangci-lint:v1.23.8 golangci-lint run --disable-all -v \
+            golangci/golangci-lint:v1.50.1 golangci-lint run --disable-all -v \
             -E govet -E misspell -E gofmt -E ineffassign -E golint
   apidiff:
     runs-on: ubuntu-latest

--- a/examples/output_test/output_test.go
+++ b/examples/output_test/output_test.go
@@ -34,18 +34,25 @@ import (
 	"k8s.io/klog/v2/textlogger"
 )
 
+func newLogger(out io.Writer, v int, vmodule string) logr.Logger {
+	return newZaprLogger(out, v)
+}
+
 // TestZaprOutput tests the zapr, directly and as backend.
 func TestZaprOutput(t *testing.T) {
 	test.InitKlog(t)
-	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
-		return newZaprLogger(out, v)
-	}
 	t.Run("direct", func(t *testing.T) {
 		test.Output(t, test.OutputConfig{NewLogger: newLogger, ExpectedOutputMapping: test.ZaprOutputMappingDirect()})
 	})
 	t.Run("klog-backend", func(t *testing.T) {
 		test.Output(t, test.OutputConfig{NewLogger: newLogger, AsBackend: true, ExpectedOutputMapping: test.ZaprOutputMappingIndirect()})
 	})
+}
+
+// Benchmark direct zapr output.
+func BenchmarkZaprOutput(b *testing.B) {
+	test.InitKlog(b)
+	test.Benchmark(b, test.OutputConfig{NewLogger: newLogger, ExpectedOutputMapping: test.ZaprOutputMappingDirect()})
 }
 
 // TestKlogrStackText tests klogr.klogr -> klog -> text logger.

--- a/examples/output_test/output_test.go
+++ b/examples/output_test/output_test.go
@@ -34,33 +34,6 @@ import (
 	"k8s.io/klog/v2/textlogger"
 )
 
-// TestKlogOutput tests klog output without a logger.
-func TestKlogOutput(t *testing.T) {
-	test.InitKlog(t)
-	test.Output(t, test.OutputConfig{})
-}
-
-// TestTextloggerOutput tests the textlogger, directly and as backend.
-func TestTextloggerOutput(t *testing.T) {
-	test.InitKlog(t)
-	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
-		config := textlogger.NewConfig(
-			textlogger.Verbosity(v),
-			textlogger.Output(out),
-		)
-		if err := config.VModule().Set(vmodule); err != nil {
-			panic(err)
-		}
-		return textlogger.NewLogger(config)
-	}
-	t.Run("direct", func(t *testing.T) {
-		test.Output(t, test.OutputConfig{NewLogger: newLogger, SupportsVModule: true})
-	})
-	t.Run("klog-backend", func(t *testing.T) {
-		test.Output(t, test.OutputConfig{NewLogger: newLogger, AsBackend: true})
-	})
-}
-
 // TestZaprOutput tests the zapr, directly and as backend.
 func TestZaprOutput(t *testing.T) {
 	test.InitKlog(t)
@@ -72,16 +45,6 @@ func TestZaprOutput(t *testing.T) {
 	})
 	t.Run("klog-backend", func(t *testing.T) {
 		test.Output(t, test.OutputConfig{NewLogger: newLogger, AsBackend: true, ExpectedOutputMapping: test.ZaprOutputMappingIndirect()})
-	})
-}
-
-// TestKlogrOutput tests klogr output via klog.
-func TestKlogrOutput(t *testing.T) {
-	test.InitKlog(t)
-	test.Output(t, test.OutputConfig{
-		NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
-			return klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog))
-		},
 	})
 }
 

--- a/examples/output_test/output_test.go
+++ b/examples/output_test/output_test.go
@@ -34,17 +34,15 @@ import (
 	"k8s.io/klog/v2/textlogger"
 )
 
-func init() {
-	test.InitKlog()
-}
-
 // TestKlogOutput tests klog output without a logger.
 func TestKlogOutput(t *testing.T) {
+	test.InitKlog(t)
 	test.Output(t, test.OutputConfig{})
 }
 
 // TestTextloggerOutput tests the textlogger, directly and as backend.
 func TestTextloggerOutput(t *testing.T) {
+	test.InitKlog(t)
 	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
 		config := textlogger.NewConfig(
 			textlogger.Verbosity(v),
@@ -65,6 +63,7 @@ func TestTextloggerOutput(t *testing.T) {
 
 // TestZaprOutput tests the zapr, directly and as backend.
 func TestZaprOutput(t *testing.T) {
+	test.InitKlog(t)
 	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
 		return newZaprLogger(out, v)
 	}
@@ -78,6 +77,7 @@ func TestZaprOutput(t *testing.T) {
 
 // TestKlogrOutput tests klogr output via klog.
 func TestKlogrOutput(t *testing.T) {
+	test.InitKlog(t)
 	test.Output(t, test.OutputConfig{
 		NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
 			return klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog))
@@ -87,6 +87,7 @@ func TestKlogrOutput(t *testing.T) {
 
 // TestKlogrStackText tests klogr.klogr -> klog -> text logger.
 func TestKlogrStackText(t *testing.T) {
+	test.InitKlog(t)
 	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
 		// Backend: text output.
 		config := textlogger.NewConfig(
@@ -110,6 +111,7 @@ func TestKlogrStackText(t *testing.T) {
 // (https://github.com/kubernetes/klog/issues/294) because klogr logging
 // records that.
 func TestKlogrStackZapr(t *testing.T) {
+	test.InitKlog(t)
 	mapping := test.ZaprOutputMappingIndirect()
 
 	// klogr doesn't warn about invalid KVs and just inserts
@@ -150,6 +152,7 @@ func TestKlogrStackZapr(t *testing.T) {
 
 // TestKlogrInternalStackText tests klog.klogr (the simplified version used for contextual logging) -> klog -> text logger.
 func TestKlogrInternalStackText(t *testing.T) {
+	test.InitKlog(t)
 	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
 		// Backend: text output.
 		config := textlogger.NewConfig(
@@ -173,6 +176,7 @@ func TestKlogrInternalStackText(t *testing.T) {
 // (https://github.com/kubernetes/klog/issues/294) because klogr logging
 // records that.
 func TestKlogrInternalStackZapr(t *testing.T) {
+	test.InitKlog(t)
 	mapping := test.ZaprOutputMappingIndirect()
 
 	// klogr doesn't warn about invalid KVs and just inserts

--- a/internal/serialize/keyvalues.go
+++ b/internal/serialize/keyvalues.go
@@ -91,6 +91,51 @@ func MergeKVs(first, second []interface{}) []interface{} {
 	return merged
 }
 
+// MergeKVsInto is a variant of MergeKVs which directly formats the key/value
+// pairs into a buffer.
+func MergeAndFormatKVs(b *bytes.Buffer, first, second []interface{}) {
+	if len(first) == 0 && len(second) == 0 {
+		// Nothing to do at all.
+		return
+	}
+
+	if len(first) == 0 && len(second)%2 == 0 {
+		// Nothing to be overridden, second slice is well-formed
+		// and can be used directly.
+		for i := 0; i < len(second); i += 2 {
+			KVFormat(b, second[i], second[i+1])
+		}
+		return
+	}
+
+	// Determine which keys are in the second slice so that we can skip
+	// them when iterating over the first one. The code intentionally
+	// favors performance over completeness: we assume that keys are string
+	// constants and thus compare equal when the string values are equal. A
+	// string constant being overridden by, for example, a fmt.Stringer is
+	// not handled.
+	overrides := map[interface{}]bool{}
+	for i := 0; i < len(second); i += 2 {
+		overrides[second[i]] = true
+	}
+	for i := 0; i < len(first); i += 2 {
+		key := first[i]
+		if overrides[key] {
+			continue
+		}
+		KVFormat(b, key, first[i+1])
+	}
+	// Round down.
+	l := len(second)
+	l = l / 2 * 2
+	for i := 1; i < l; i += 2 {
+		KVFormat(b, second[i-1], second[i])
+	}
+	if len(second)%2 == 1 {
+		KVFormat(b, second[len(second)-1], missingValue)
+	}
+}
+
 const missingValue = "(MISSING)"
 
 // KVListFormat serializes all key/value pairs into the provided buffer.
@@ -104,66 +149,72 @@ func KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
 		} else {
 			v = missingValue
 		}
-		b.WriteByte(' ')
-		// Keys are assumed to be well-formed according to
-		// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
-		// for the sake of performance. Keys with spaces,
-		// special characters, etc. will break parsing.
-		if sK, ok := k.(string); ok {
-			// Avoid one allocation when the key is a string, which
-			// normally it should be.
-			b.WriteString(sK)
-		} else {
-			b.WriteString(fmt.Sprintf("%s", k))
-		}
+		KVFormat(b, k, v)
+	}
+}
 
-		// The type checks are sorted so that more frequently used ones
-		// come first because that is then faster in the common
-		// cases. In Kubernetes, ObjectRef (a Stringer) is more common
-		// than plain strings
-		// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
-		switch v := v.(type) {
-		case fmt.Stringer:
-			writeStringValue(b, true, StringerToString(v))
+// KVFormat serializes one key/value pair into the provided buffer.
+// A space gets inserted before the pair.
+func KVFormat(b *bytes.Buffer, k, v interface{}) {
+	b.WriteByte(' ')
+	// Keys are assumed to be well-formed according to
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
+	// for the sake of performance. Keys with spaces,
+	// special characters, etc. will break parsing.
+	if sK, ok := k.(string); ok {
+		// Avoid one allocation when the key is a string, which
+		// normally it should be.
+		b.WriteString(sK)
+	} else {
+		b.WriteString(fmt.Sprintf("%s", k))
+	}
+
+	// The type checks are sorted so that more frequently used ones
+	// come first because that is then faster in the common
+	// cases. In Kubernetes, ObjectRef (a Stringer) is more common
+	// than plain strings
+	// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
+	switch v := v.(type) {
+	case fmt.Stringer:
+		writeStringValue(b, true, StringerToString(v))
+	case string:
+		writeStringValue(b, true, v)
+	case error:
+		writeStringValue(b, true, ErrorToString(v))
+	case logr.Marshaler:
+		value := MarshalerToValue(v)
+		// A marshaler that returns a string is useful for
+		// delayed formatting of complex values. We treat this
+		// case like a normal string. This is useful for
+		// multi-line support.
+		//
+		// We could do this by recursively formatting a value,
+		// but that comes with the risk of infinite recursion
+		// if a marshaler returns itself. Instead we call it
+		// only once and rely on it returning the intended
+		// value directly.
+		switch value := value.(type) {
 		case string:
-			writeStringValue(b, true, v)
-		case error:
-			writeStringValue(b, true, ErrorToString(v))
-		case logr.Marshaler:
-			value := MarshalerToValue(v)
-			// A marshaler that returns a string is useful for
-			// delayed formatting of complex values. We treat this
-			// case like a normal string. This is useful for
-			// multi-line support.
-			//
-			// We could do this by recursively formatting a value,
-			// but that comes with the risk of infinite recursion
-			// if a marshaler returns itself. Instead we call it
-			// only once and rely on it returning the intended
-			// value directly.
-			switch value := value.(type) {
-			case string:
-				writeStringValue(b, true, value)
-			default:
-				writeStringValue(b, false, fmt.Sprintf("%+v", value))
-			}
-		case []byte:
-			// In https://github.com/kubernetes/klog/pull/237 it was decided
-			// to format byte slices with "%+q". The advantages of that are:
-			// - readable output if the bytes happen to be printable
-			// - non-printable bytes get represented as unicode escape
-			//   sequences (\uxxxx)
-			//
-			// The downsides are that we cannot use the faster
-			// strconv.Quote here and that multi-line output is not
-			// supported. If developers know that a byte array is
-			// printable and they want multi-line output, they can
-			// convert the value to string before logging it.
-			b.WriteByte('=')
-			b.WriteString(fmt.Sprintf("%+q", v))
+			writeStringValue(b, true, value)
 		default:
-			writeStringValue(b, false, fmt.Sprintf("%+v", v))
+			writeStringValue(b, false, fmt.Sprintf("%+v", value))
 		}
+	case []byte:
+		// In https://github.com/kubernetes/klog/pull/237 it was decided
+		// to format byte slices with "%+q". The advantages of that are:
+		// - readable output if the bytes happen to be printable
+		// - non-printable bytes get represented as unicode escape
+		//   sequences (\uxxxx)
+		//
+		// The downsides are that we cannot use the faster
+		// strconv.Quote here and that multi-line output is not
+		// supported. If developers know that a byte array is
+		// printable and they want multi-line output, they can
+		// convert the value to string before logging it.
+		b.WriteByte('=')
+		b.WriteString(fmt.Sprintf("%+q", v))
+	default:
+		writeStringValue(b, false, fmt.Sprintf("%+v", v))
 	}
 }
 

--- a/k8s_references.go
+++ b/k8s_references.go
@@ -19,6 +19,7 @@ package klog
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
 )
@@ -31,7 +32,12 @@ type ObjectRef struct {
 
 func (ref ObjectRef) String() string {
 	if ref.Namespace != "" {
-		return fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)
+		var builder strings.Builder
+		builder.Grow(len(ref.Namespace) + len(ref.Name) + 1)
+		builder.WriteString(ref.Namespace)
+		builder.WriteRune('/')
+		builder.WriteString(ref.Name)
+		return builder.String()
 	}
 	return ref.Name
 }

--- a/k8s_references.go
+++ b/k8s_references.go
@@ -17,6 +17,7 @@ limitations under the License.
 package klog
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strings"
@@ -40,6 +41,20 @@ func (ref ObjectRef) String() string {
 		return builder.String()
 	}
 	return ref.Name
+}
+
+func (ref ObjectRef) WriteText(out *bytes.Buffer) {
+	out.WriteRune('"')
+	ref.writeUnquoted(out)
+	out.WriteRune('"')
+}
+
+func (ref ObjectRef) writeUnquoted(out *bytes.Buffer) {
+	if ref.Namespace != "" {
+		out.WriteString(ref.Namespace)
+		out.WriteRune('/')
+	}
+	out.WriteString(ref.Name)
 }
 
 // MarshalLog ensures that loggers with support for structured output will log
@@ -123,31 +138,31 @@ var _ fmt.Stringer = kobjSlice{}
 var _ logr.Marshaler = kobjSlice{}
 
 func (ks kobjSlice) String() string {
-	objectRefs, err := ks.process()
-	if err != nil {
-		return err.Error()
+	objectRefs, errStr := ks.process()
+	if errStr != "" {
+		return errStr
 	}
 	return fmt.Sprintf("%v", objectRefs)
 }
 
 func (ks kobjSlice) MarshalLog() interface{} {
-	objectRefs, err := ks.process()
-	if err != nil {
-		return err.Error()
+	objectRefs, errStr := ks.process()
+	if errStr != "" {
+		return errStr
 	}
 	return objectRefs
 }
 
-func (ks kobjSlice) process() ([]interface{}, error) {
+func (ks kobjSlice) process() (objs []interface{}, err string) {
 	s := reflect.ValueOf(ks.arg)
 	switch s.Kind() {
 	case reflect.Invalid:
 		// nil parameter, print as nil.
-		return nil, nil
+		return nil, ""
 	case reflect.Slice:
 		// Okay, handle below.
 	default:
-		return nil, fmt.Errorf("<KObjSlice needs a slice, got type %T>", ks.arg)
+		return nil, fmt.Sprintf("<KObjSlice needs a slice, got type %T>", ks.arg)
 	}
 	objectRefs := make([]interface{}, 0, s.Len())
 	for i := 0; i < s.Len(); i++ {
@@ -157,8 +172,41 @@ func (ks kobjSlice) process() ([]interface{}, error) {
 		} else if v, ok := item.(KMetadata); ok {
 			objectRefs = append(objectRefs, KObj(v))
 		} else {
-			return nil, fmt.Errorf("<KObjSlice needs a slice of values implementing KMetadata, got type %T>", item)
+			return nil, fmt.Sprintf("<KObjSlice needs a slice of values implementing KMetadata, got type %T>", item)
 		}
 	}
-	return objectRefs, nil
+	return objectRefs, ""
+}
+
+var nilToken = []byte("<nil>")
+
+func (ks kobjSlice) WriteText(out *bytes.Buffer) {
+	s := reflect.ValueOf(ks.arg)
+	switch s.Kind() {
+	case reflect.Invalid:
+		// nil parameter, print as empty slice.
+		out.WriteString("[]")
+		return
+	case reflect.Slice:
+		// Okay, handle below.
+	default:
+		fmt.Fprintf(out, `"<KObjSlice needs a slice, got type %T>"`, ks.arg)
+		return
+	}
+	out.Write([]byte{'['})
+	defer out.Write([]byte{']'})
+	for i := 0; i < s.Len(); i++ {
+		if i > 0 {
+			out.Write([]byte{' '})
+		}
+		item := s.Index(i).Interface()
+		if item == nil {
+			out.Write(nilToken)
+		} else if v, ok := item.(KMetadata); ok {
+			KObj(v).writeUnquoted(out)
+		} else {
+			fmt.Fprintf(out, "<KObjSlice needs a slice of values implementing KMetadata, got type %T>", item)
+			return
+		}
+	}
 }

--- a/klog.go
+++ b/klog.go
@@ -532,11 +532,6 @@ func (s settings) deepCopy() settings {
 type loggingT struct {
 	settings
 
-	// bufferCache maintains the free list. It uses its own mutex
-	// so buffers can be grabbed and printed to without holding the main lock,
-	// for better parallelization.
-	bufferCache buffer.Buffers
-
 	// flushD holds a flushDaemon that frequently flushes log file buffers.
 	// Uses its own mutex.
 	flushD *flushDaemon
@@ -664,7 +659,7 @@ func (l *loggingT) header(s severity.Severity, depth int) (*buffer.Buffer, strin
 
 // formatHeader formats a log header using the provided file name and line number.
 func (l *loggingT) formatHeader(s severity.Severity, file string, line int) *buffer.Buffer {
-	buf := l.bufferCache.GetBuffer()
+	buf := buffer.GetBuffer()
 	if l.skipHeaders {
 		return buf
 	}
@@ -682,8 +677,8 @@ func (l *loggingT) printlnDepth(s severity.Severity, logger *logr.Logger, filter
 	// if logger is set, we clear the generated header as we rely on the backing
 	// logger implementation to print headers
 	if logger != nil {
-		l.bufferCache.PutBuffer(buf)
-		buf = l.bufferCache.GetBuffer()
+		buffer.PutBuffer(buf)
+		buf = buffer.GetBuffer()
 	}
 	if filter != nil {
 		args = filter.Filter(args)
@@ -701,8 +696,8 @@ func (l *loggingT) printDepth(s severity.Severity, logger *logr.Logger, filter L
 	// if logr is set, we clear the generated header as we rely on the backing
 	// logr implementation to print headers
 	if logger != nil {
-		l.bufferCache.PutBuffer(buf)
-		buf = l.bufferCache.GetBuffer()
+		buffer.PutBuffer(buf)
+		buf = buffer.GetBuffer()
 	}
 	if filter != nil {
 		args = filter.Filter(args)
@@ -723,8 +718,8 @@ func (l *loggingT) printfDepth(s severity.Severity, logger *logr.Logger, filter 
 	// if logr is set, we clear the generated header as we rely on the backing
 	// logr implementation to print headers
 	if logger != nil {
-		l.bufferCache.PutBuffer(buf)
-		buf = l.bufferCache.GetBuffer()
+		buffer.PutBuffer(buf)
+		buf = buffer.GetBuffer()
 	}
 	if filter != nil {
 		format, args = filter.FilterF(format, args)
@@ -744,8 +739,8 @@ func (l *loggingT) printWithFileLine(s severity.Severity, logger *logr.Logger, f
 	// if logr is set, we clear the generated header as we rely on the backing
 	// logr implementation to print headers
 	if logger != nil {
-		l.bufferCache.PutBuffer(buf)
-		buf = l.bufferCache.GetBuffer()
+		buffer.PutBuffer(buf)
+		buf = buffer.GetBuffer()
 	}
 	if filter != nil {
 		args = filter.Filter(args)
@@ -785,7 +780,7 @@ func (l *loggingT) infoS(logger *logr.Logger, filter LogFilter, depth int, msg s
 // set log severity by s
 func (l *loggingT) printS(err error, s severity.Severity, depth int, msg string, keysAndValues ...interface{}) {
 	// Only create a new buffer if we don't have one cached.
-	b := l.bufferCache.GetBuffer()
+	b := buffer.GetBuffer()
 	// The message is always quoted, even if it contains line breaks.
 	// If developers want multi-line output, they should use a small, fixed
 	// message and put the multi-line output into a value.
@@ -796,7 +791,7 @@ func (l *loggingT) printS(err error, s severity.Severity, depth int, msg string,
 	serialize.KVListFormat(&b.Buffer, keysAndValues...)
 	l.printDepth(s, logging.logger, nil, depth+1, &b.Buffer)
 	// Make the buffer available for reuse.
-	l.bufferCache.PutBuffer(b)
+	buffer.PutBuffer(b)
 }
 
 // redirectBuffer is used to set an alternate destination for the logs
@@ -948,7 +943,7 @@ func (l *loggingT) output(s severity.Severity, log *logr.Logger, buf *buffer.Buf
 		timeoutFlush(ExitFlushTimeout)
 		OsExit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
 	}
-	l.bufferCache.PutBuffer(buf)
+	buffer.PutBuffer(buf)
 
 	if stats := severityStats[s]; stats != nil {
 		atomic.AddInt64(&stats.lines, 1)

--- a/klog.go
+++ b/klog.go
@@ -1313,6 +1313,13 @@ func newVerbose(level Level, b bool) Verbose {
 // less than or equal to the value of the -vmodule pattern matching the source file
 // containing the call.
 func V(level Level) Verbose {
+	return VDepth(1, level)
+}
+
+// VDepth is a variant of V that accepts a number of stack frames that will be
+// skipped when checking the -vmodule patterns. VDepth(0) is equivalent to
+// V().
+func VDepth(depth int, level Level) Verbose {
 	// This function tries hard to be cheap unless there's work to do.
 	// The fast path is two atomic loads and compares.
 
@@ -1329,7 +1336,7 @@ func V(level Level) Verbose {
 		// but if V logging is enabled we're slow anyway.
 		logging.mu.Lock()
 		defer logging.mu.Unlock()
-		if runtime.Callers(2, logging.pcs[:]) == 0 {
+		if runtime.Callers(2+depth, logging.pcs[:]) == 0 {
 			return newVerbose(level, false)
 		}
 		// runtime.Callers returns "return PCs", but we want

--- a/klog_test.go
+++ b/klog_test.go
@@ -623,7 +623,7 @@ func TestLogBacktraceAt(t *testing.T) {
 func BenchmarkHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		buf, _, _ := logging.header(severity.InfoLog, 0)
-		logging.bufferCache.PutBuffer(buf)
+		buffer.PutBuffer(buf)
 	}
 }
 
@@ -631,7 +631,7 @@ func BenchmarkHeaderWithDir(b *testing.B) {
 	logging.addDirHeader = true
 	for i := 0; i < b.N; i++ {
 		buf, _, _ := logging.header(severity.InfoLog, 0)
-		logging.bufferCache.PutBuffer(buf)
+		buffer.PutBuffer(buf)
 	}
 }
 

--- a/klogr.go
+++ b/klogr.go
@@ -42,7 +42,7 @@ func (l *klogger) Init(info logr.RuntimeInfo) {
 	l.callDepth += info.CallDepth
 }
 
-func (l klogger) Info(level int, msg string, kvList ...interface{}) {
+func (l *klogger) Info(level int, msg string, kvList ...interface{}) {
 	merged := serialize.MergeKVs(l.values, kvList)
 	if l.prefix != "" {
 		msg = l.prefix + ": " + msg
@@ -50,11 +50,11 @@ func (l klogger) Info(level int, msg string, kvList ...interface{}) {
 	V(Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
 }
 
-func (l klogger) Enabled(level int) bool {
+func (l *klogger) Enabled(level int) bool {
 	return V(Level(level)).Enabled()
 }
 
-func (l klogger) Error(err error, msg string, kvList ...interface{}) {
+func (l *klogger) Error(err error, msg string, kvList ...interface{}) {
 	merged := serialize.MergeKVs(l.values, kvList)
 	if l.prefix != "" {
 		msg = l.prefix + ": " + msg

--- a/klogr.go
+++ b/klogr.go
@@ -47,11 +47,13 @@ func (l *klogger) Info(level int, msg string, kvList ...interface{}) {
 	if l.prefix != "" {
 		msg = l.prefix + ": " + msg
 	}
-	V(Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
+	// Skip this function.
+	VDepth(l.callDepth+1, Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
 }
 
 func (l *klogger) Enabled(level int) bool {
-	return V(Level(level)).Enabled()
+	// Skip this function and logr.Logger.Info where Enabled is called.
+	return VDepth(l.callDepth+2, Level(level)).Enabled()
 }
 
 func (l *klogger) Error(err error, msg string, kvList ...interface{}) {

--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -119,7 +119,7 @@ func pretty(value interface{}) string {
 	return strings.TrimSpace(string(buffer.Bytes()))
 }
 
-func (l klogger) Info(level int, msg string, kvList ...interface{}) {
+func (l *klogger) Info(level int, msg string, kvList ...interface{}) {
 	switch l.format {
 	case FormatSerialize:
 		msgStr := flatten("msg", msg)
@@ -135,11 +135,11 @@ func (l klogger) Info(level int, msg string, kvList ...interface{}) {
 	}
 }
 
-func (l klogger) Enabled(level int) bool {
+func (l *klogger) Enabled(level int) bool {
 	return klog.V(klog.Level(level)).Enabled()
 }
 
-func (l klogger) Error(err error, msg string, kvList ...interface{}) {
+func (l *klogger) Error(err error, msg string, kvList ...interface{}) {
 	msgStr := flatten("msg", msg)
 	var loggableErr interface{}
 	if err != nil {

--- a/klogr/klogr.go
+++ b/klogr/klogr.go
@@ -125,18 +125,19 @@ func (l *klogger) Info(level int, msg string, kvList ...interface{}) {
 		msgStr := flatten("msg", msg)
 		merged := serialize.MergeKVs(l.values, kvList)
 		kvStr := flatten(merged...)
-		klog.V(klog.Level(level)).InfoDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", kvStr)
+		klog.VDepth(l.callDepth+1, klog.Level(level)).InfoDepth(l.callDepth+1, l.prefix, " ", msgStr, " ", kvStr)
 	case FormatKlog:
 		merged := serialize.MergeKVs(l.values, kvList)
 		if l.prefix != "" {
 			msg = l.prefix + ": " + msg
 		}
-		klog.V(klog.Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
+		klog.VDepth(l.callDepth+1, klog.Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
 	}
 }
 
 func (l *klogger) Enabled(level int) bool {
-	return klog.V(klog.Level(level)).Enabled()
+	// Skip this function and logr.Logger.Info where Enabled is called.
+	return klog.VDepth(l.callDepth+2, klog.Level(level)).Enabled()
 }
 
 func (l *klogger) Error(err error, msg string, kvList ...interface{}) {

--- a/klogr/klogr_test.go
+++ b/klogr/klogr_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"flag"
 	"strings"
 	"testing"
 
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/test"
 
 	"github.com/go-logr/logr"
 )
@@ -169,14 +169,9 @@ func testOutput(t *testing.T, format string) {
 			klogr: new().V(0),
 			text:  "test",
 			err:   errors.New("whoops"),
-			// The message is printed to three different log files (info, warning, error), so we see it three times in our output buffer.
 			expectedOutput: ` "msg"="test" "error"="whoops" 
- "msg"="test" "error"="whoops" 
- "msg"="test" "error"="whoops" 
 `,
 			expectedKlogOutput: `"test" err="whoops"
-"test" err="whoops"
-"test" err="whoops"
 `,
 		},
 	}
@@ -209,13 +204,8 @@ func testOutput(t *testing.T, format string) {
 }
 
 func TestOutput(t *testing.T) {
-	klog.InitFlags(nil)
-	flag.CommandLine.Set("v", "10")
-	flag.CommandLine.Set("skip_headers", "true")
-	flag.CommandLine.Set("logtostderr", "false")
-	flag.CommandLine.Set("alsologtostderr", "false")
-	flag.CommandLine.Set("stderrthreshold", "10")
-	flag.Parse()
+	fs := test.InitKlog(t)
+	fs.Set("skip_headers", "true")
 
 	formats := []string{
 		formatNew,

--- a/klogr/output_test.go
+++ b/klogr/output_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klogr_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/test"
+)
+
+// TestKlogrOutput tests klogr output via klog.
+func TestKlogrOutput(t *testing.T) {
+	test.InitKlog(t)
+	test.Output(t, test.OutputConfig{
+		NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
+			return klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog))
+		},
+	})
+}

--- a/ktesting/testinglogger.go
+++ b/ktesting/testinglogger.go
@@ -319,8 +319,7 @@ func (l tlogger) Info(level int, msg string, kvList ...interface{}) {
 
 	l.shared.t.Helper()
 	buffer := &bytes.Buffer{}
-	merged := serialize.MergeKVs(l.values, kvList)
-	serialize.KVListFormat(buffer, merged...)
+	serialize.MergeAndFormatKVs(buffer, l.values, kvList)
 	l.log(LogInfo, msg, level, buffer, nil, kvList)
 }
 
@@ -339,10 +338,9 @@ func (l tlogger) Error(err error, msg string, kvList ...interface{}) {
 	l.shared.t.Helper()
 	buffer := &bytes.Buffer{}
 	if err != nil {
-		serialize.KVListFormat(buffer, "err", err)
+		serialize.KVFormat(buffer, "err", err)
 	}
-	merged := serialize.MergeKVs(l.values, kvList)
-	serialize.KVListFormat(buffer, merged...)
+	serialize.MergeAndFormatKVs(buffer, l.values, kvList)
 	l.log(LogError, msg, 0, buffer, err, kvList)
 }
 

--- a/output_test.go
+++ b/output_test.go
@@ -26,18 +26,27 @@ import (
 	"k8s.io/klog/v2/test"
 )
 
-// TestKlogOutput tests klog output without a logger.
+// klogConfig tests klog output without a logger.
+var klogConfig = test.OutputConfig{}
+
 func TestKlogOutput(t *testing.T) {
 	test.InitKlog(t)
-	test.Output(t, test.OutputConfig{})
+	test.Output(t, klogConfig)
 }
 
-// TestKlogKlogrOutput tests klogr output via klog, using the klog/v2 klogr.
+func BenchmarkKlogOutput(b *testing.B) {
+	test.InitKlog(b)
+	test.Benchmark(b, klogConfig)
+}
+
+// klogKlogrConfig tests klogr output via klog, using the klog/v2 klogr.
+var klogKLogrConfig = test.OutputConfig{
+	NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
+		return klog.NewKlogr()
+	},
+}
+
 func TestKlogrOutput(t *testing.T) {
 	test.InitKlog(t)
-	test.Output(t, test.OutputConfig{
-		NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
-			return klog.NewKlogr()
-		},
-	})
+	test.Output(t, klogKLogrConfig)
 }

--- a/output_test.go
+++ b/output_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/test"
+)
+
+// TestKlogOutput tests klog output without a logger.
+func TestKlogOutput(t *testing.T) {
+	test.InitKlog(t)
+	test.Output(t, test.OutputConfig{})
+}
+
+// TestKlogKlogrOutput tests klogr output via klog, using the klog/v2 klogr.
+func TestKlogrOutput(t *testing.T) {
+	test.InitKlog(t)
+	test.Output(t, test.OutputConfig{
+		NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
+			return klog.NewKlogr()
+		},
+	})
+}

--- a/test/output.go
+++ b/test/output.go
@@ -290,14 +290,14 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 				&kmeta{Name: "pod-1", Namespace: "kube-system"},
 				&kmeta{Name: "pod-2", Namespace: "kube-system"},
 			})},
-		expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 kube-system/pod-2]"
+		expectedOutput: `I output.go:<LINE>] "test" pods=[kube-system/pod-1 kube-system/pod-2]
 `,
 	},
 	"KObjSlice nil arg": {
 		text: "test",
 		values: []interface{}{"pods",
 			klog.KObjSlice(nil)},
-		expectedOutput: `I output.go:<LINE>] "test" pods="[]"
+		expectedOutput: `I output.go:<LINE>] "test" pods=[]
 `,
 	},
 	"KObjSlice int arg": {
@@ -314,14 +314,14 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 				&kmeta{Name: "pod-1", Namespace: "kube-system"},
 				nil,
 			})},
-		expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 <nil>]"
+		expectedOutput: `I output.go:<LINE>] "test" pods=[kube-system/pod-1 <nil>]
 `,
 	},
 	"KObjSlice ints": {
 		text: "test",
 		values: []interface{}{"ints",
 			klog.KObjSlice([]int{1, 2, 3})},
-		expectedOutput: `I output.go:<LINE>] "test" ints="<KObjSlice needs a slice of values implementing KMetadata, got type int>"
+		expectedOutput: `I output.go:<LINE>] "test" ints=[<KObjSlice needs a slice of values implementing KMetadata, got type int>]
 `,
 	},
 	"regular error types as value": {
@@ -357,7 +357,7 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 	"MarshalLog() for nil": {
 		text:   "marshaler nil",
 		values: []interface{}{"obj", (*klog.ObjectRef)(nil)},
-		expectedOutput: `I output.go:<LINE>] "marshaler nil" obj="<panic: value method k8s.io/klog/v2.ObjectRef.String called using nil *ObjectRef pointer>"
+		expectedOutput: `I output.go:<LINE>] "marshaler nil" obj="<panic: value method k8s.io/klog/v2.ObjectRef.WriteText called using nil *ObjectRef pointer>"
 `,
 	},
 	"Error() that panics": {

--- a/test/output.go
+++ b/test/output.go
@@ -108,6 +108,389 @@ type OutputConfig struct {
 	SupportsVModule bool
 }
 
+type testcase struct {
+	withHelper bool // use wrappers that get skipped during stack unwinding
+	withNames  []string
+	// For a first WithValues call: logger1 := logger.WithValues()
+	withValues []interface{}
+	// For another WithValues call: logger2 := logger1.WithValues()
+	moreValues []interface{}
+	// For another WithValues call on the same logger as before: logger3 := logger1.WithValues()
+	evenMoreValues []interface{}
+	v              int
+	vmodule        string
+	text           string
+	values         []interface{}
+	err            error
+	expectedOutput string
+}
+
+var tests = map[string]testcase{
+	"log with values": {
+		text:   "test",
+		values: []interface{}{"akey", "avalue"},
+		expectedOutput: `I output.go:<LINE>] "test" akey="avalue"
+`,
+	},
+	"call depth": {
+		text:       "helper",
+		withHelper: true,
+		values:     []interface{}{"akey", "avalue"},
+		expectedOutput: `I output.go:<LINE>] "helper" akey="avalue"
+`,
+	},
+	"verbosity enabled": {
+		text: "you see me",
+		v:    9,
+		expectedOutput: `I output.go:<LINE>] "you see me"
+`,
+	},
+	"verbosity disabled": {
+		text: "you don't see me",
+		v:    11,
+	},
+	"vmodule": {
+		text:    "v=11: you see me because of -vmodule output=11",
+		v:       11,
+		vmodule: "output=11",
+	},
+	"other vmodule": {
+		text:    "v=11: you still don't see me because of -vmodule output_helper=11",
+		v:       11,
+		vmodule: "output_helper=11",
+	},
+	"log with name and values": {
+		withNames: []string{"me"},
+		text:      "test",
+		values:    []interface{}{"akey", "avalue"},
+		expectedOutput: `I output.go:<LINE>] "me: test" akey="avalue"
+`,
+	},
+	"log with multiple names and values": {
+		withNames: []string{"hello", "world"},
+		text:      "test",
+		values:    []interface{}{"akey", "avalue"},
+		expectedOutput: `I output.go:<LINE>] "hello/world: test" akey="avalue"
+`,
+	},
+	"override single value": {
+		withValues: []interface{}{"akey", "avalue"},
+		text:       "test",
+		values:     []interface{}{"akey", "avalue2"},
+		expectedOutput: `I output.go:<LINE>] "test" akey="avalue2"
+`,
+	},
+	"override WithValues": {
+		withValues: []interface{}{"duration", time.Hour, "X", "y"},
+		text:       "test",
+		values:     []interface{}{"duration", time.Minute, "A", "b"},
+		expectedOutput: `I output.go:<LINE>] "test" X="y" duration="1m0s" A="b"
+`,
+	},
+	"odd WithValues": {
+		withValues: []interface{}{"keyWithoutValue"},
+		moreValues: []interface{}{"anotherKeyWithoutValue"},
+		text:       "odd WithValues",
+		expectedOutput: `I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
+I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)" anotherKeyWithoutValue="(MISSING)"
+I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
+`,
+	},
+	"multiple WithValues": {
+		withValues:     []interface{}{"firstKey", 1},
+		moreValues:     []interface{}{"secondKey", 2},
+		evenMoreValues: []interface{}{"secondKey", 3},
+		text:           "test",
+		expectedOutput: `I output.go:<LINE>] "test" firstKey=1
+I output.go:<LINE>] "test" firstKey=1 secondKey=2
+I output.go:<LINE>] "test" firstKey=1
+I output.go:<LINE>] "test" firstKey=1 secondKey=3
+`,
+	},
+	"empty WithValues": {
+		withValues: []interface{}{},
+		text:       "test",
+		expectedOutput: `I output.go:<LINE>] "test"
+`,
+	},
+	"print duplicate keys in arguments": {
+		text:   "test",
+		values: []interface{}{"akey", "avalue", "akey", "avalue2"},
+		expectedOutput: `I output.go:<LINE>] "test" akey="avalue" akey="avalue2"
+`,
+	},
+	"preserve order of key/value pairs": {
+		withValues: []interface{}{"akey9", "avalue9", "akey8", "avalue8", "akey1", "avalue1"},
+		text:       "test",
+		values:     []interface{}{"akey5", "avalue5", "akey4", "avalue4"},
+		expectedOutput: `I output.go:<LINE>] "test" akey9="avalue9" akey8="avalue8" akey1="avalue1" akey5="avalue5" akey4="avalue4"
+`,
+	},
+	"handle odd-numbers of KVs": {
+		text:   "odd arguments",
+		values: []interface{}{"akey", "avalue", "akey2"},
+		expectedOutput: `I output.go:<LINE>] "odd arguments" akey="avalue" akey2="(MISSING)"
+`,
+	},
+	"html characters": {
+		text:   "test",
+		values: []interface{}{"akey", "<&>"},
+		expectedOutput: `I output.go:<LINE>] "test" akey="<&>"
+`,
+	},
+	"quotation": {
+		text:   `"quoted"`,
+		values: []interface{}{"key", `"quoted value"`},
+		expectedOutput: `I output.go:<LINE>] "\"quoted\"" key="\"quoted value\""
+`,
+	},
+	"handle odd-numbers of KVs in both log values and Info args": {
+		withValues: []interface{}{"basekey1", "basevar1", "basekey2"},
+		text:       "both odd",
+		values:     []interface{}{"akey", "avalue", "akey2"},
+		expectedOutput: `I output.go:<LINE>] "both odd" basekey1="basevar1" basekey2="(MISSING)" akey="avalue" akey2="(MISSING)"
+`,
+	},
+	"KObj": {
+		text:   "test",
+		values: []interface{}{"pod", klog.KObj(&kmeta{Name: "pod-1", Namespace: "kube-system"})},
+		expectedOutput: `I output.go:<LINE>] "test" pod="kube-system/pod-1"
+`,
+	},
+	"KObjs": {
+		text: "test",
+		values: []interface{}{"pods",
+			klog.KObjs([]interface{}{
+				&kmeta{Name: "pod-1", Namespace: "kube-system"},
+				&kmeta{Name: "pod-2", Namespace: "kube-system"},
+			})},
+		expectedOutput: `I output.go:<LINE>] "test" pods=[kube-system/pod-1 kube-system/pod-2]
+`,
+	},
+	"KObjSlice okay": {
+		text: "test",
+		values: []interface{}{"pods",
+			klog.KObjSlice([]interface{}{
+				&kmeta{Name: "pod-1", Namespace: "kube-system"},
+				&kmeta{Name: "pod-2", Namespace: "kube-system"},
+			})},
+		expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 kube-system/pod-2]"
+`,
+	},
+	"KObjSlice nil arg": {
+		text: "test",
+		values: []interface{}{"pods",
+			klog.KObjSlice(nil)},
+		expectedOutput: `I output.go:<LINE>] "test" pods="[]"
+`,
+	},
+	"KObjSlice int arg": {
+		text: "test",
+		values: []interface{}{"pods",
+			klog.KObjSlice(1)},
+		expectedOutput: `I output.go:<LINE>] "test" pods="<KObjSlice needs a slice, got type int>"
+`,
+	},
+	"KObjSlice nil entry": {
+		text: "test",
+		values: []interface{}{"pods",
+			klog.KObjSlice([]interface{}{
+				&kmeta{Name: "pod-1", Namespace: "kube-system"},
+				nil,
+			})},
+		expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 <nil>]"
+`,
+	},
+	"KObjSlice ints": {
+		text: "test",
+		values: []interface{}{"ints",
+			klog.KObjSlice([]int{1, 2, 3})},
+		expectedOutput: `I output.go:<LINE>] "test" ints="<KObjSlice needs a slice of values implementing KMetadata, got type int>"
+`,
+	},
+	"regular error types as value": {
+		text:   "test",
+		values: []interface{}{"err", errors.New("whoops")},
+		expectedOutput: `I output.go:<LINE>] "test" err="whoops"
+`,
+	},
+	"ignore MarshalJSON": {
+		text:   "test",
+		values: []interface{}{"err", &customErrorJSON{"whoops"}},
+		expectedOutput: `I output.go:<LINE>] "test" err="whoops"
+`,
+	},
+	"regular error types when using logr.Error": {
+		text: "test",
+		err:  errors.New("whoops"),
+		expectedOutput: `E output.go:<LINE>] "test" err="whoops"
+`,
+	},
+	"Error() for nil": {
+		text: "error nil",
+		err:  (*customErrorJSON)(nil),
+		expectedOutput: `E output.go:<LINE>] "error nil" err="<panic: runtime error: invalid memory address or nil pointer dereference>"
+`,
+	},
+	"String() for nil": {
+		text:   "stringer nil",
+		values: []interface{}{"stringer", (*stringer)(nil)},
+		expectedOutput: `I output.go:<LINE>] "stringer nil" stringer="<panic: runtime error: invalid memory address or nil pointer dereference>"
+`,
+	},
+	"MarshalLog() for nil": {
+		text:   "marshaler nil",
+		values: []interface{}{"obj", (*klog.ObjectRef)(nil)},
+		expectedOutput: `I output.go:<LINE>] "marshaler nil" obj="<panic: value method k8s.io/klog/v2.ObjectRef.String called using nil *ObjectRef pointer>"
+`,
+	},
+	"Error() that panics": {
+		text: "error panic",
+		err:  faultyError{},
+		expectedOutput: `E output.go:<LINE>] "error panic" err="<panic: fake Error panic>"
+`,
+	},
+	"String() that panics": {
+		text:   "stringer panic",
+		values: []interface{}{"stringer", faultyStringer{}},
+		expectedOutput: `I output.go:<LINE>] "stringer panic" stringer="<panic: fake String panic>"
+`,
+	},
+	"MarshalLog() that panics": {
+		text:   "marshaler panic",
+		values: []interface{}{"obj", faultyMarshaler{}},
+		expectedOutput: `I output.go:<LINE>] "marshaler panic" obj="<panic: fake MarshalLog panic>"
+`,
+	},
+	"MarshalLog() that returns itself": {
+		text:   "marshaler recursion",
+		values: []interface{}{"obj", recursiveMarshaler{}},
+		expectedOutput: `I output.go:<LINE>] "marshaler recursion" obj={}
+`,
+	},
+	"handle integer keys": {
+		withValues: []interface{}{1, "value", 2, "value2"},
+		text:       "integer keys",
+		values:     []interface{}{"akey", "avalue", "akey2"},
+		expectedOutput: `I output.go:<LINE>] "integer keys" %!s(int=1)="value" %!s(int=2)="value2" akey="avalue" akey2="(MISSING)"
+`,
+	},
+	"struct keys": {
+		withValues: []interface{}{struct{ name string }{"name"}, "value", "test", "other value"},
+		text:       "struct keys",
+		values:     []interface{}{"key", "val"},
+		expectedOutput: `I output.go:<LINE>] "struct keys" {name}="value" test="other value" key="val"
+`,
+	},
+	"map keys": {
+		withValues: []interface{}{},
+		text:       "map keys",
+		values:     []interface{}{map[string]bool{"test": true}, "test"},
+		expectedOutput: `I output.go:<LINE>] "map keys" map[test:%!s(bool=true)]="test"
+`,
+	},
+}
+
+func printWithLogger(logger logr.Logger, test testcase) {
+	for _, name := range test.withNames {
+		logger = logger.WithName(name)
+	}
+	// When we have multiple WithValues calls, we test
+	// first with the initial set of additional values, then
+	// the combination, then again the original logger.
+	// It must not have been modified. This produces
+	// three log entries.
+	logger = logger.WithValues(test.withValues...) // <WITH-VALUES>
+	loggers := []logr.Logger{logger}
+	if test.moreValues != nil {
+		loggers = append(loggers, logger.WithValues(test.moreValues...), logger) // <WITH-VALUES-2>
+	}
+	if test.evenMoreValues != nil {
+		loggers = append(loggers, logger.WithValues(test.evenMoreValues...)) // <WITH-VALUES-3>
+	}
+	for _, logger := range loggers {
+		if test.withHelper {
+			loggerHelper(logger, test.text, test.values) // <LINE>
+		} else if test.err != nil {
+			logger.Error(test.err, test.text, test.values...) // <LINE>
+		} else {
+			logger.V(test.v).Info(test.text, test.values...) // <LINE>
+		}
+	}
+}
+
+var _, _, printWithLoggerLine, _ = runtime.Caller(0) // anchor for finding the line numbers above
+
+func initPrintWithKlog(tb testing.TB, test testcase) {
+	if test.withHelper && test.vmodule != "" {
+		tb.Skip("klog does not support -vmodule properly when using helper functions")
+	}
+
+	state := klog.CaptureState()
+	tb.Cleanup(state.Restore)
+
+	var fs flag.FlagSet
+	klog.InitFlags(&fs)
+	if err := fs.Set("v", "10"); err != nil {
+		tb.Fatalf("unexpected error: %v", err)
+	}
+	if err := fs.Set("vmodule", test.vmodule); err != nil {
+		tb.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func printWithKlog(test testcase) {
+	kv := []interface{}{}
+	haveKeyInValues := func(key interface{}) bool {
+		for i := 0; i < len(test.values); i += 2 {
+			if key == test.values[i] {
+				return true
+			}
+		}
+		return false
+	}
+	appendKV := func(withValues []interface{}) {
+		if len(withValues)%2 != 0 {
+			withValues = append(withValues, "(MISSING)")
+		}
+		for i := 0; i < len(withValues); i += 2 {
+			if !haveKeyInValues(withValues[i]) {
+				kv = append(kv, withValues[i], withValues[i+1])
+			}
+		}
+	}
+	// Here we need to emulate the handling of WithValues above.
+	appendKV(test.withValues)
+	kvs := [][]interface{}{copySlice(kv)}
+	if test.moreValues != nil {
+		appendKV(test.moreValues)
+		kvs = append(kvs, copySlice(kv), copySlice(kvs[0]))
+	}
+	if test.evenMoreValues != nil {
+		kv = copySlice(kvs[0])
+		appendKV(test.evenMoreValues)
+		kvs = append(kvs, copySlice(kv))
+	}
+	for _, kv := range kvs {
+		if len(test.values) > 0 {
+			kv = append(kv, test.values...)
+		}
+		text := test.text
+		if len(test.withNames) > 0 {
+			text = strings.Join(test.withNames, "/") + ": " + text
+		}
+		if test.withHelper {
+			klogHelper(text, kv)
+		} else if test.err != nil {
+			klog.ErrorS(test.err, text, kv...)
+		} else {
+			klog.V(klog.Level(test.v)).InfoS(text, kv...)
+		}
+	}
+}
+
+var _, _, printWithKlogLine, _ = runtime.Caller(0) // anchor for finding the line numbers above
+
 // Output covers various special cases of emitting log output.
 // It can be used for arbitrary logr.Logger implementations.
 //
@@ -125,369 +508,9 @@ type OutputConfig struct {
 // later release. The test cases and thus the expected output also may
 // change.
 func Output(t *testing.T, config OutputConfig) {
-	tests := map[string]struct {
-		withHelper bool // use wrappers that get skipped during stack unwinding
-		withNames  []string
-		// For a first WithValues call: logger1 := logger.WithValues()
-		withValues []interface{}
-		// For another WithValues call: logger2 := logger1.WithValues()
-		moreValues []interface{}
-		// For another WithValues call on the same logger as before: logger3 := logger1.WithValues()
-		evenMoreValues []interface{}
-		v              int
-		vmodule        string
-		text           string
-		values         []interface{}
-		err            error
-		expectedOutput string
-	}{
-		"log with values": {
-			text:   "test",
-			values: []interface{}{"akey", "avalue"},
-			expectedOutput: `I output.go:<LINE>] "test" akey="avalue"
-`,
-		},
-		"call depth": {
-			text:       "helper",
-			withHelper: true,
-			values:     []interface{}{"akey", "avalue"},
-			expectedOutput: `I output.go:<LINE>] "helper" akey="avalue"
-`,
-		},
-		"verbosity enabled": {
-			text: "you see me",
-			v:    9,
-			expectedOutput: `I output.go:<LINE>] "you see me"
-`,
-		},
-		"verbosity disabled": {
-			text: "you don't see me",
-			v:    11,
-		},
-		"vmodule": {
-			text:    "v=11: you see me because of -vmodule output=11",
-			v:       11,
-			vmodule: "output=11",
-		},
-		"other vmodule": {
-			text:    "v=11: you still don't see me because of -vmodule output_helper=11",
-			v:       11,
-			vmodule: "output_helper=11",
-		},
-		"log with name and values": {
-			withNames: []string{"me"},
-			text:      "test",
-			values:    []interface{}{"akey", "avalue"},
-			expectedOutput: `I output.go:<LINE>] "me: test" akey="avalue"
-`,
-		},
-		"log with multiple names and values": {
-			withNames: []string{"hello", "world"},
-			text:      "test",
-			values:    []interface{}{"akey", "avalue"},
-			expectedOutput: `I output.go:<LINE>] "hello/world: test" akey="avalue"
-`,
-		},
-		"override single value": {
-			withValues: []interface{}{"akey", "avalue"},
-			text:       "test",
-			values:     []interface{}{"akey", "avalue2"},
-			expectedOutput: `I output.go:<LINE>] "test" akey="avalue2"
-`,
-		},
-		"override WithValues": {
-			withValues: []interface{}{"duration", time.Hour, "X", "y"},
-			text:       "test",
-			values:     []interface{}{"duration", time.Minute, "A", "b"},
-			expectedOutput: `I output.go:<LINE>] "test" X="y" duration="1m0s" A="b"
-`,
-		},
-		"odd WithValues": {
-			withValues: []interface{}{"keyWithoutValue"},
-			moreValues: []interface{}{"anotherKeyWithoutValue"},
-			text:       "odd WithValues",
-			expectedOutput: `I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
-I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)" anotherKeyWithoutValue="(MISSING)"
-I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
-`,
-		},
-		"multiple WithValues": {
-			withValues:     []interface{}{"firstKey", 1},
-			moreValues:     []interface{}{"secondKey", 2},
-			evenMoreValues: []interface{}{"secondKey", 3},
-			text:           "test",
-			expectedOutput: `I output.go:<LINE>] "test" firstKey=1
-I output.go:<LINE>] "test" firstKey=1 secondKey=2
-I output.go:<LINE>] "test" firstKey=1
-I output.go:<LINE>] "test" firstKey=1 secondKey=3
-`,
-		},
-		"empty WithValues": {
-			withValues: []interface{}{},
-			text:       "test",
-			expectedOutput: `I output.go:<LINE>] "test"
-`,
-		},
-		"print duplicate keys in arguments": {
-			text:   "test",
-			values: []interface{}{"akey", "avalue", "akey", "avalue2"},
-			expectedOutput: `I output.go:<LINE>] "test" akey="avalue" akey="avalue2"
-`,
-		},
-		"preserve order of key/value pairs": {
-			withValues: []interface{}{"akey9", "avalue9", "akey8", "avalue8", "akey1", "avalue1"},
-			text:       "test",
-			values:     []interface{}{"akey5", "avalue5", "akey4", "avalue4"},
-			expectedOutput: `I output.go:<LINE>] "test" akey9="avalue9" akey8="avalue8" akey1="avalue1" akey5="avalue5" akey4="avalue4"
-`,
-		},
-		"handle odd-numbers of KVs": {
-			text:   "odd arguments",
-			values: []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: `I output.go:<LINE>] "odd arguments" akey="avalue" akey2="(MISSING)"
-`,
-		},
-		"html characters": {
-			text:   "test",
-			values: []interface{}{"akey", "<&>"},
-			expectedOutput: `I output.go:<LINE>] "test" akey="<&>"
-`,
-		},
-		"quotation": {
-			text:   `"quoted"`,
-			values: []interface{}{"key", `"quoted value"`},
-			expectedOutput: `I output.go:<LINE>] "\"quoted\"" key="\"quoted value\""
-`,
-		},
-		"handle odd-numbers of KVs in both log values and Info args": {
-			withValues: []interface{}{"basekey1", "basevar1", "basekey2"},
-			text:       "both odd",
-			values:     []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: `I output.go:<LINE>] "both odd" basekey1="basevar1" basekey2="(MISSING)" akey="avalue" akey2="(MISSING)"
-`,
-		},
-		"KObj": {
-			text:   "test",
-			values: []interface{}{"pod", klog.KObj(&kmeta{Name: "pod-1", Namespace: "kube-system"})},
-			expectedOutput: `I output.go:<LINE>] "test" pod="kube-system/pod-1"
-`,
-		},
-		"KObjs": {
-			text: "test",
-			values: []interface{}{"pods",
-				klog.KObjs([]interface{}{
-					&kmeta{Name: "pod-1", Namespace: "kube-system"},
-					&kmeta{Name: "pod-2", Namespace: "kube-system"},
-				})},
-			expectedOutput: `I output.go:<LINE>] "test" pods=[kube-system/pod-1 kube-system/pod-2]
-`,
-		},
-		"KObjSlice okay": {
-			text: "test",
-			values: []interface{}{"pods",
-				klog.KObjSlice([]interface{}{
-					&kmeta{Name: "pod-1", Namespace: "kube-system"},
-					&kmeta{Name: "pod-2", Namespace: "kube-system"},
-				})},
-			expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 kube-system/pod-2]"
-`,
-		},
-		"KObjSlice nil arg": {
-			text: "test",
-			values: []interface{}{"pods",
-				klog.KObjSlice(nil)},
-			expectedOutput: `I output.go:<LINE>] "test" pods="[]"
-`,
-		},
-		"KObjSlice int arg": {
-			text: "test",
-			values: []interface{}{"pods",
-				klog.KObjSlice(1)},
-			expectedOutput: `I output.go:<LINE>] "test" pods="<KObjSlice needs a slice, got type int>"
-`,
-		},
-		"KObjSlice nil entry": {
-			text: "test",
-			values: []interface{}{"pods",
-				klog.KObjSlice([]interface{}{
-					&kmeta{Name: "pod-1", Namespace: "kube-system"},
-					nil,
-				})},
-			expectedOutput: `I output.go:<LINE>] "test" pods="[kube-system/pod-1 <nil>]"
-`,
-		},
-		"KObjSlice ints": {
-			text: "test",
-			values: []interface{}{"ints",
-				klog.KObjSlice([]int{1, 2, 3})},
-			expectedOutput: `I output.go:<LINE>] "test" ints="<KObjSlice needs a slice of values implementing KMetadata, got type int>"
-`,
-		},
-		"regular error types as value": {
-			text:   "test",
-			values: []interface{}{"err", errors.New("whoops")},
-			expectedOutput: `I output.go:<LINE>] "test" err="whoops"
-`,
-		},
-		"ignore MarshalJSON": {
-			text:   "test",
-			values: []interface{}{"err", &customErrorJSON{"whoops"}},
-			expectedOutput: `I output.go:<LINE>] "test" err="whoops"
-`,
-		},
-		"regular error types when using logr.Error": {
-			text: "test",
-			err:  errors.New("whoops"),
-			expectedOutput: `E output.go:<LINE>] "test" err="whoops"
-`,
-		},
-		"Error() for nil": {
-			text: "error nil",
-			err:  (*customErrorJSON)(nil),
-			expectedOutput: `E output.go:<LINE>] "error nil" err="<panic: runtime error: invalid memory address or nil pointer dereference>"
-`,
-		},
-		"String() for nil": {
-			text:   "stringer nil",
-			values: []interface{}{"stringer", (*stringer)(nil)},
-			expectedOutput: `I output.go:<LINE>] "stringer nil" stringer="<panic: runtime error: invalid memory address or nil pointer dereference>"
-`,
-		},
-		"MarshalLog() for nil": {
-			text:   "marshaler nil",
-			values: []interface{}{"obj", (*klog.ObjectRef)(nil)},
-			expectedOutput: `I output.go:<LINE>] "marshaler nil" obj="<panic: value method k8s.io/klog/v2.ObjectRef.String called using nil *ObjectRef pointer>"
-`,
-		},
-		"Error() that panics": {
-			text: "error panic",
-			err:  faultyError{},
-			expectedOutput: `E output.go:<LINE>] "error panic" err="<panic: fake Error panic>"
-`,
-		},
-		"String() that panics": {
-			text:   "stringer panic",
-			values: []interface{}{"stringer", faultyStringer{}},
-			expectedOutput: `I output.go:<LINE>] "stringer panic" stringer="<panic: fake String panic>"
-`,
-		},
-		"MarshalLog() that panics": {
-			text:   "marshaler panic",
-			values: []interface{}{"obj", faultyMarshaler{}},
-			expectedOutput: `I output.go:<LINE>] "marshaler panic" obj="<panic: fake MarshalLog panic>"
-`,
-		},
-		"MarshalLog() that returns itself": {
-			text:   "marshaler recursion",
-			values: []interface{}{"obj", recursiveMarshaler{}},
-			expectedOutput: `I output.go:<LINE>] "marshaler recursion" obj={}
-`,
-		},
-		"handle integer keys": {
-			withValues: []interface{}{1, "value", 2, "value2"},
-			text:       "integer keys",
-			values:     []interface{}{"akey", "avalue", "akey2"},
-			expectedOutput: `I output.go:<LINE>] "integer keys" %!s(int=1)="value" %!s(int=2)="value2" akey="avalue" akey2="(MISSING)"
-`,
-		},
-		"struct keys": {
-			withValues: []interface{}{struct{ name string }{"name"}, "value", "test", "other value"},
-			text:       "struct keys",
-			values:     []interface{}{"key", "val"},
-			expectedOutput: `I output.go:<LINE>] "struct keys" {name}="value" test="other value" key="val"
-`,
-		},
-		"map keys": {
-			withValues: []interface{}{},
-			text:       "map keys",
-			values:     []interface{}{map[string]bool{"test": true}, "test"},
-			expectedOutput: `I output.go:<LINE>] "map keys" map[test:%!s(bool=true)]="test"
-`,
-		},
-	}
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
 			defer klog.ClearLogger()
-
-			printWithLogger := func(logger logr.Logger) {
-				for _, name := range test.withNames {
-					logger = logger.WithName(name)
-				}
-				// When we have multiple WithValues calls, we test
-				// first with the initial set of additional values, then
-				// the combination, then again the original logger.
-				// It must not have been modified. This produces
-				// three log entries.
-				logger = logger.WithValues(test.withValues...) // <WITH-VALUES>
-				loggers := []logr.Logger{logger}
-				if test.moreValues != nil {
-					loggers = append(loggers, logger.WithValues(test.moreValues...), logger) // <WITH-VALUES-2>
-				}
-				if test.evenMoreValues != nil {
-					loggers = append(loggers, logger.WithValues(test.evenMoreValues...)) // <WITH-VALUES-3>
-				}
-				for _, logger := range loggers {
-					if test.withHelper {
-						loggerHelper(logger, test.text, test.values) // <LINE>
-					} else if test.err != nil {
-						logger.Error(test.err, test.text, test.values...) // <LINE>
-					} else {
-						logger.V(test.v).Info(test.text, test.values...) // <LINE>
-					}
-				}
-			}
-			_, _, printWithLoggerLine, _ := runtime.Caller(0)
-
-			printWithKlog := func() {
-				kv := []interface{}{}
-				haveKeyInValues := func(key interface{}) bool {
-					for i := 0; i < len(test.values); i += 2 {
-						if key == test.values[i] {
-							return true
-						}
-					}
-					return false
-				}
-				appendKV := func(withValues []interface{}) {
-					if len(withValues)%2 != 0 {
-						withValues = append(withValues, "(MISSING)")
-					}
-					for i := 0; i < len(withValues); i += 2 {
-						if !haveKeyInValues(withValues[i]) {
-							kv = append(kv, withValues[i], withValues[i+1])
-						}
-					}
-				}
-				// Here we need to emulate the handling of WithValues above.
-				appendKV(test.withValues)
-				kvs := [][]interface{}{copySlice(kv)}
-				if test.moreValues != nil {
-					appendKV(test.moreValues)
-					kvs = append(kvs, copySlice(kv), copySlice(kvs[0]))
-				}
-				if test.evenMoreValues != nil {
-					kv = copySlice(kvs[0])
-					appendKV(test.evenMoreValues)
-					kvs = append(kvs, copySlice(kv))
-				}
-				for _, kv := range kvs {
-					if len(test.values) > 0 {
-						kv = append(kv, test.values...)
-					}
-					text := test.text
-					if len(test.withNames) > 0 {
-						text = strings.Join(test.withNames, "/") + ": " + text
-					}
-					if test.withHelper {
-						klogHelper(text, kv)
-					} else if test.err != nil {
-						klog.ErrorS(test.err, text, kv...)
-					} else {
-						klog.V(klog.Level(test.v)).InfoS(text, kv...)
-					}
-				}
-			}
-			_, _, printWithKlogLine, _ := runtime.Caller(0)
 
 			testOutput := func(t *testing.T, expectedLine int, print func(buffer *bytes.Buffer)) {
 				var tmpWriteBuffer bytes.Buffer
@@ -530,16 +553,16 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 
 			if config.NewLogger == nil {
 				// Test klog.
-				testOutput(t, printWithKlogLine, func(buffer *bytes.Buffer) {
-					printWithKlog()
+				testOutput(t, printWithKlogLine-1, func(buffer *bytes.Buffer) {
+					printWithKlog(test)
 				})
 				return
 			}
 
 			if config.AsBackend {
-				testOutput(t, printWithKlogLine, func(buffer *bytes.Buffer) {
+				testOutput(t, printWithKlogLine-1, func(buffer *bytes.Buffer) {
 					klog.SetLogger(config.NewLogger(buffer, 10, ""))
-					printWithKlog()
+					printWithKlog(test)
 				})
 				return
 			}
@@ -548,8 +571,8 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 				t.Skip("vmodule not supported")
 			}
 
-			testOutput(t, printWithLoggerLine, func(buffer *bytes.Buffer) {
-				printWithLogger(config.NewLogger(buffer, 10, test.vmodule))
+			testOutput(t, printWithLoggerLine-1, func(buffer *bytes.Buffer) {
+				printWithLogger(config.NewLogger(buffer, 10, test.vmodule), test)
 			})
 		})
 	}
@@ -780,6 +803,55 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 				}
 			})
 		}
+	}
+}
+
+// Benchmark covers various special cases of emitting log output.
+// It can be used for arbitrary logr.Logger implementations.
+//
+// Loggers will be tested with direct calls to Info or
+// as backend for klog.
+//
+// # Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release. The test cases and thus the expected output also may
+// change.
+func Benchmark(b *testing.B, config OutputConfig) {
+	for n, test := range tests {
+		b.Run(n, func(b *testing.B) {
+			state := klog.CaptureState()
+			defer state.Restore()
+			klog.SetOutput(io.Discard)
+			initPrintWithKlog(b, test)
+			b.ResetTimer()
+
+			if config.NewLogger == nil {
+				// Test klog.
+				for i := 0; i < b.N; i++ {
+					printWithKlog(test)
+				}
+				return
+			}
+
+			if config.AsBackend {
+				klog.SetLogger(config.NewLogger(io.Discard, 10, ""))
+				for i := 0; i < b.N; i++ {
+					printWithKlog(test)
+				}
+				return
+			}
+
+			if test.vmodule != "" && !config.SupportsVModule {
+				b.Skip("vmodule not supported")
+			}
+
+			logger := config.NewLogger(io.Discard, 10, test.vmodule)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				printWithLogger(logger, test)
+			}
+		})
 	}
 }
 

--- a/test/output_helper.go
+++ b/test/output_helper.go
@@ -27,6 +27,6 @@ func loggerHelper(logger logr.Logger, msg string, kv []interface{}) {
 	logger.Info(msg, kv...)
 }
 
-func klogHelper(msg string, kv []interface{}) {
-	klog.InfoSDepth(1, msg, kv...)
+func klogHelper(level klog.Level, msg string, kv []interface{}) {
+	klog.V(level).InfoSDepth(1, msg, kv...)
 }

--- a/test/zapr.go
+++ b/test/zapr.go
@@ -319,6 +319,11 @@ I output.go:<LINE>] "test" firstKey=1 secondKey=3
 `: `{"caller":"test/output.go:<LINE>","msg":"non-string key argument passed to logging, ignoring all later arguments","invalid key":{"test":true}}
 {"caller":"test/output.go:<LINE>","msg":"map keys","v":0}
 `,
+
+		// zapr does not support vmodule checks and thus always
+		// discards these messages.
+		`I output.go:<LINE>] "v=11: you see me because of -vmodule output=11"
+`: ``,
 	} {
 		mapping[key] = value
 	}

--- a/test/zapr.go
+++ b/test/zapr.go
@@ -73,11 +73,7 @@ func ZaprOutputMappingDirect() map[string]string {
 `: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":[{"name":"pod-1","namespace":"kube-system"},{"name":"pod-2","namespace":"kube-system"}]}
 `,
 
-		`I output.go:<LINE>] "test" pods="[kube-system/pod-1 kube-system/pod-2]"
-`: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":[{"name":"pod-1","namespace":"kube-system"},{"name":"pod-2","namespace":"kube-system"}]}
-`,
-
-		`I output.go:<LINE>] "test" pods="[]"
+		`I output.go:<LINE>] "test" pods=[]
 `: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":null}
 `,
 
@@ -85,11 +81,11 @@ func ZaprOutputMappingDirect() map[string]string {
 `: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":"<KObjSlice needs a slice, got type int>"}
 `,
 
-		`I output.go:<LINE>] "test" ints="<KObjSlice needs a slice of values implementing KMetadata, got type int>"
+		`I output.go:<LINE>] "test" ints=[<KObjSlice needs a slice of values implementing KMetadata, got type int>]
 `: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"ints":"<KObjSlice needs a slice of values implementing KMetadata, got type int>"}
 `,
 
-		`I output.go:<LINE>] "test" pods="[kube-system/pod-1 <nil>]"
+		`I output.go:<LINE>] "test" pods=[kube-system/pod-1 <nil>]
 `: `{"caller":"test/output.go:<LINE>","msg":"test","v":0,"pods":[{"name":"pod-1","namespace":"kube-system"},null]}
 `,
 
@@ -140,7 +136,7 @@ I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
 {"caller":"test/output.go:<LINE>","msg":"both odd","basekey1":"basevar1","v":0,"akey":"avalue"}
 `,
 
-		`I output.go:<LINE>] "marshaler nil" obj="<panic: value method k8s.io/klog/v2.ObjectRef.String called using nil *ObjectRef pointer>"
+		`I output.go:<LINE>] "marshaler nil" obj="<panic: value method k8s.io/klog/v2.ObjectRef.WriteText called using nil *ObjectRef pointer>"
 `: `{"caller":"test/output.go:<LINE>","msg":"marshaler nil","v":0,"objError":"PANIC=value method k8s.io/klog/v2.ObjectRef.MarshalLog called using nil *ObjectRef pointer"}
 `,
 

--- a/textlogger/output_test.go
+++ b/textlogger/output_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package textlogger_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/test"
+	"k8s.io/klog/v2/textlogger"
+)
+
+// TestTextloggerOutput tests the textlogger, directly and as backend.
+func TestTextloggerOutput(t *testing.T) {
+	test.InitKlog(t)
+	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
+		config := textlogger.NewConfig(
+			textlogger.Verbosity(v),
+			textlogger.Output(out),
+		)
+		if err := config.VModule().Set(vmodule); err != nil {
+			panic(err)
+		}
+		return textlogger.NewLogger(config)
+	}
+	t.Run("direct", func(t *testing.T) {
+		test.Output(t, test.OutputConfig{NewLogger: newLogger, SupportsVModule: true})
+	})
+	t.Run("klog-backend", func(t *testing.T) {
+		test.Output(t, test.OutputConfig{NewLogger: newLogger, AsBackend: true})
+	})
+}

--- a/textlogger/textlogger.go
+++ b/textlogger/textlogger.go
@@ -125,10 +125,9 @@ func (l *tlogger) print(err error, s severity.Severity, msg string, kvList []int
 	// message and put the multi-line output into a value.
 	b.WriteString(strconv.Quote(msg))
 	if err != nil {
-		serialize.KVListFormat(&b.Buffer, "err", err)
+		serialize.KVFormat(&b.Buffer, "err", err)
 	}
-	merged := serialize.MergeKVs(l.values, kvList)
-	serialize.KVListFormat(&b.Buffer, merged...)
+	serialize.MergeAndFormatKVs(&b.Buffer, l.values, kvList)
 	if b.Len() == 0 || b.Bytes()[b.Len()-1] != '\n' {
 		b.WriteByte('\n')
 	}

--- a/textlogger/textlogger.go
+++ b/textlogger/textlogger.go
@@ -69,12 +69,6 @@ type tlogger struct {
 	config    *Config
 }
 
-func copySlice(in []interface{}) []interface{} {
-	out := make([]interface{}, len(in))
-	copy(out, in)
-	return out
-}
-
 func (l *tlogger) Init(info logr.RuntimeInfo) {
 	l.callDepth = info.CallDepth
 }

--- a/textlogger/textlogger.go
+++ b/textlogger/textlogger.go
@@ -56,19 +56,17 @@ var (
 // later release. The behavior of the returned Logger may change.
 func NewLogger(c *Config) logr.Logger {
 	return logr.New(&tlogger{
-		prefix:      "",
-		values:      nil,
-		config:      c,
-		bufferCache: &buffer.Buffers{},
+		prefix: "",
+		values: nil,
+		config: c,
 	})
 }
 
 type tlogger struct {
-	callDepth   int
-	prefix      string
-	values      []interface{}
-	config      *Config
-	bufferCache *buffer.Buffers
+	callDepth int
+	prefix    string
+	values    []interface{}
+	config    *Config
 }
 
 func copySlice(in []interface{}) []interface{} {
@@ -103,7 +101,8 @@ func (l *tlogger) Error(err error, msg string, kvList ...interface{}) {
 
 func (l *tlogger) print(err error, s severity.Severity, msg string, kvList []interface{}) {
 	// Only create a new buffer if we don't have one cached.
-	b := l.bufferCache.GetBuffer()
+	b := buffer.GetBuffer()
+	defer buffer.PutBuffer(b)
 
 	// Determine caller.
 	// +1 for this frame, +1 for Info/Error.

--- a/textlogger/textlogger.go
+++ b/textlogger/textlogger.go
@@ -88,7 +88,9 @@ func (l *tlogger) WithCallDepth(depth int) logr.LogSink {
 }
 
 func (l *tlogger) Enabled(level int) bool {
-	return l.config.Enabled(verbosity.Level(level), 1)
+	// Skip this function and the Logger.Info call, then
+	// also any additional stack frames from WithCallDepth.
+	return l.config.Enabled(verbosity.Level(level), 2+l.callDepth)
 }
 
 func (l *tlogger) Info(level int, msg string, kvList ...interface{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a combination of several performance improvements. 

Eventually the goal is to use just that textlogger in Kubernetes, without going through any of the klog APIs like klog.Info nor through the legacy output handling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #360
Fixes #334

**Special notes for your reviewer**:

**Release note**:
```release-note
improved performance
```