### PR TITLE
buffer: restore dropping of too large buffers

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -55,6 +55,17 @@ func GetBuffer() *Buffer {
 
 // PutBuffer returns a buffer to the free list.
 func PutBuffer(b *Buffer) {
+	if b.Len() >= 256 {
+		// Let big buffers die a natural death, without relying on
+		// sync.Pool behavior. The documentation implies that items may
+		// get deallocated while stored there ("If the Pool holds the
+		// only reference when this [= be removed automatically]
+		// happens, the item might be deallocated."), but
+		// https://github.com/golang/go/issues/23199 leans more towards
+		// having such a size limit.
+		return
+	}
+
 	buffers.Put(b)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This was removed when introducing sync.Pool in commit 1a1367cc64e28f8bf3dcc04cd74010cc67bdd57d because it seemed unnecessary, but an open issue about the sync.Pool documentation shows that a size limit may be useful after all.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #364 

**Special notes for your reviewer**:

This is blocking https://github.com/kubernetes/kubernetes/pull/115277.

**Release note**:
```release-note
NONE
```