### PR TITLE
expose logBridge via NewStandardLog()

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -1217,6 +1217,19 @@ func CopyStandardLogTo(name string) {
 	stdLog.SetOutput(logBridge(sev))
 }
 
+// NewStandardLogger returns a Logger that writes to the klog logs for the
+// named and lower severities.
+//
+// Valid names are "INFO", "WARNING", "ERROR", and "FATAL". If the name is not
+// recognized, NewStandardLogger panics.
+func NewStandardLogger(name string) *stdLog.Logger {
+	sev, ok := severity.ByName(name)
+	if !ok {
+		panic(fmt.Sprintf("klog.NewStandardLogger(%q): unknown severity", name))
+	}
+	return stdLog.New(logBridge(sev), "", stdLog.Lshortfile)
+}
+
 // logBridge provides the Write method that enables CopyStandardLogTo to connect
 // Go's standard logs to the logs provided by this package.
 type logBridge severity.Severity


### PR DESCRIPTION
Various libraries, including stdlib, accept *log.Logger to support optional logging. Let's expose logBridge to facilitate working with these libraries.

stdlib examples:
* [http.Server.ErrorLog]
* [httputil.ReverseProxy.ErrorLog]

[http.Server.ErrorLog]: https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/net/http/server.go;l=2679-2683;drc=ea4631cc0cf301c824bd665a7980c13289ab5c9d
[httputil.ReverseProxy.ErrorLog]: https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/net/http/httputil/reverseproxy.go;l=173-176;drc=458241f981e0a8e1d9e0b2f6ae53be62f00001d2

```release-note
NONE
```