### PR TITLE
Programmatically set oneOutput flag

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -1700,3 +1700,11 @@ type LogFilter interface {
 func SetLogFilter(filter LogFilter) {
 	logging.filter = filter
 }
+
+// SetOneOutput sets whether to only write logs to their native severity level
+func SetOneOutput(oneOutput bool) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+
+	logging.oneOutput = oneOutput
+}

--- a/klog_test.go
+++ b/klog_test.go
@@ -2214,3 +2214,26 @@ func TestSettingsDeepCopy(t *testing.T) {
 		t.Fatal("Copy should not have shared vmodule.filter.")
 	}
 }
+
+// Test the SetOneOutput(bool) function can programatically set that
+// logs are only written to their native severity level.
+func TestSetOneOutput(t *testing.T) {
+	defer CaptureState().Restore()
+	setFlags()
+	SetOneOutput(true)
+	defer logging.swap(logging.newBuffers())
+	Error("test")
+	if !contains(severity.ErrorLog, "E", t) {
+		t.Errorf("Error has wrong character: %q", contents(severity.ErrorLog))
+	}
+	if !contains(severity.ErrorLog, "test", t) {
+		t.Error("Error failed")
+	}
+	str := contents(severity.ErrorLog)
+	if contains(severity.WarningLog, str, t) {
+		t.Error("Warning failed")
+	}
+	if contains(severity.InfoLog, str, t) {
+		t.Error("Info failed")
+	}
+}


### PR DESCRIPTION
This enhancement enables an application to programatically set the `logging.oneOutput` flag without needing to expose the klog flags on the command line. It aligns with the existing functions `LogToStderr(..)` and `SetOutputBySeverity(..)`, such that one can direct messages to different output destinations and control whether those messages are only written to their native severity level.

**What this PR does / why we need it**:

The enhancement introduces a new function `SetOneOutput(bool)` that updates the value of the `logging.oneOutput` flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
addition of SetOneOutput function
```