### PR TITLE
stderrthreshold: fix flag comment

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -415,7 +415,7 @@ func init() {
 	logging.stderrThreshold = severityValue{
 		Severity: severity.ErrorLog, // Default stderrThreshold is ERROR.
 	}
-	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false)")
+	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true)")
 	commandLine.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	commandLine.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
 

--- a/klog_test.go
+++ b/klog_test.go
@@ -913,7 +913,7 @@ func TestCommandLine(t *testing.T) {
   -skip_log_headers
     	If true, avoid headers when opening log files (no effect when -logtostderr=true)
   -stderrthreshold value
-    	logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+    	logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
   -v value
     	number for the log level verbosity
   -vmodule value


### PR DESCRIPTION
**What this PR does / why we need it**:

The code is so that the -stderrthreshold gets ignored when -alsologtostderr=true.


**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/klog/issues/371

**Release note**:
```release-note
Fixed command line help for -stderrthreshold: it has no effect when   -alsologtostderr=true.
```