### PR TITLE
fix: SetLogger via klog.SetLogger will output an unexpected newline

### DIFF
--- a/examples/flushing/.gitignore
+++ b/examples/flushing/.gitignore
@@ -1,0 +1,1 @@
+myfile.log

--- a/klog.go
+++ b/klog.go
@@ -873,6 +873,9 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 		if logger.writeKlogBuffer != nil {
 			logger.writeKlogBuffer(data)
 		} else {
+			if len(data) > 0 && data[len(data)-1] == '\n' {
+				data = data[:len(data)-1]
+			}
 			// TODO: set 'severity' and caller information as structured log info
 			// keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
 			if s == severity.ErrorLog {

--- a/klog_test.go
+++ b/klog_test.go
@@ -1484,13 +1484,13 @@ func TestInfoWithLogr(t *testing.T) {
 		msg: "foo",
 		expected: testLogrEntry{
 			severity: severity.InfoLog,
-			msg:      "foo\n",
+			msg:      "foo",
 		},
 	}, {
 		msg: "",
 		expected: testLogrEntry{
 			severity: severity.InfoLog,
-			msg:      "\n",
+			msg:      "",
 		},
 	}}
 

--- a/test/zapr.go
+++ b/test/zapr.go
@@ -171,22 +171,22 @@ I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
 
 		// klog.Info
 		`I output.go:<LINE>] "helloworld\n"
-`: `{"caller":"test/output.go:<LINE>","msg":"helloworld\n","v":0}
+`: `{"caller":"test/output.go:<LINE>","msg":"helloworld","v":0}
 `,
 
 		// klog.Infoln
 		`I output.go:<LINE>] "hello world\n"
-`: `{"caller":"test/output.go:<LINE>","msg":"hello world\n","v":0}
+`: `{"caller":"test/output.go:<LINE>","msg":"hello world","v":0}
 `,
 
 		// klog.Error
 		`E output.go:<LINE>] "helloworld\n"
-`: `{"caller":"test/output.go:<LINE>","msg":"helloworld\n"}
+`: `{"caller":"test/output.go:<LINE>","msg":"helloworld"}
 `,
 
 		// klog.Errorln
 		`E output.go:<LINE>] "hello world\n"
-`: `{"caller":"test/output.go:<LINE>","msg":"hello world\n"}
+`: `{"caller":"test/output.go:<LINE>","msg":"hello world"}
 `,
 
 		// klog.ErrorS
@@ -201,12 +201,12 @@ I output.go:<LINE>] "odd WithValues" keyWithoutValue="(MISSING)"
 
 		// klog.V(1).Info
 		`I output.go:<LINE>] "hellooneworld\n"
-`: `{"caller":"test/output.go:<LINE>","msg":"hellooneworld\n","v":1}
+`: `{"caller":"test/output.go:<LINE>","msg":"hellooneworld","v":1}
 `,
 
 		// klog.V(1).Infoln
 		`I output.go:<LINE>] "hello one world\n"
-`: `{"caller":"test/output.go:<LINE>","msg":"hello one world\n","v":1}
+`: `{"caller":"test/output.go:<LINE>","msg":"hello one world","v":1}
 `,
 
 		// klog.V(1).ErrorS


### PR DESCRIPTION
klog always adds a newline to the msg. klog will work fine without klog.

Set logr with klog.SetLogger, and klog will also pass the msg with the newline added to logr, which will result in an accidental newline being added.

step1: klog.Info("hello world")
step2: msg = msg + "\n"
step3: stdout.W(msg) or logr.Info(msg[:len(msg)-1])

fixes #370

Signed-off-by: aimuz <mr.imuz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```