### PR TITLE
Set log level through function

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -438,6 +438,11 @@ func InitFlags(flagset *flag.FlagSet) {
 	})
 }
 
+// SetVerbosity set log level through function.
+func SetVerbosity(level Level) {
+	logging.verbosity = level
+}
+
 // Flush flushes all pending log I/O.
 func Flush() {
 	logging.lockAndFlushAll()

--- a/klog_test.go
+++ b/klog_test.go
@@ -325,7 +325,7 @@ func TestV(t *testing.T) {
 	defer CaptureState().Restore()
 	setFlags()
 	defer logging.swap(logging.newBuffers())
-	logging.verbosity.Set("2")
+	SetVerbosity(2)
 	V(2).Info("test")
 	if !contains(severity.InfoLog, "I", t) {
 		t.Errorf("Info has wrong character: %q", contents(severity.InfoLog))


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The log level can be set through functions,
Not only can it be set by flags, but also by functions.

A  app  has a debug flag. enable the debug flag parameter, I hope that all the klog logs can be printed out. 
But the klog log level can only be set through flag
 

**Special notes for your reviewer**:


**Release note**:
```release-note
None
```