### PR TITLE
Add SafePtr wrapper

### DIFF
--- a/safeptr.go
+++ b/safeptr.go
@@ -1,0 +1,34 @@
+//go:build go1.18
+// +build go1.18
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+// SafePtr is a function that takes a pointer of any type (T) as an argument.
+// If the provided pointer is not nil, it returns the same pointer. If it is nil, it returns nil instead.
+//
+// This function is particularly useful to prevent nil pointer dereferencing when:
+//
+//   - The type implements interfaces that are called by the logger, such as `fmt.Stringer`.
+//   - And these interface implementations do not perform nil checks themselves.
+func SafePtr[T any](p *T) any {
+	if p == nil {
+		return nil
+	}
+	return p
+}

--- a/safeptr_test.go
+++ b/safeptr_test.go
@@ -1,0 +1,41 @@
+//go:build go1.18
+// +build go1.18
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog_test
+
+import (
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+func TestSafePtr(t *testing.T) {
+	// Test with nil pointer
+	var stringPtr *string
+	if result := klog.SafePtr(stringPtr); result != nil {
+		t.Errorf("Expected nil, got %p", result)
+	}
+
+	// Test with non-nil pointer
+	expected := "foo"
+	stringPtr = &expected
+	if result := klog.SafePtr(stringPtr); result != stringPtr {
+		t.Errorf("Expected %v, got %v", stringPtr, result)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

If a nil pointer value is provided when logging, it will be dereferenced leading to a panic message. This PR adds a simple wrapper called `SafePtr` which helps preventing this by returning a nil interface in case the provided pointer is nil, or the same pointer if it's not nil.

This function is available when compiling with Go >= 1.18 since it uses generics.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add SafePtr wrapper
```