### PR TITLE
Implemented IDE file navigation feature in buffer.go

### DIFF
--- a/examples/klogr/main.go
+++ b/examples/klogr/main.go
@@ -19,6 +19,7 @@ func (e myError) Error() string {
 func main() {
 	klog.InitFlags(nil)
 	require.NoError(flag.Set("v", "3"))
+	require.NoError(flag.Set("hyperlink_headers", "true"))
 	flag.Parse()
 	log := klogr.New().WithName("MyName").WithValues("user", "you")
 	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -148,9 +148,10 @@ func (buf *Buffer) FormatHeader(s severity.Severity, file string, line int, now 
 	buf.WriteString(file)
 	buf.Tmp[0] = ':'
 	n := buf.someDigits(1, line)
-	buf.Tmp[n+1] = ']'
-	buf.Tmp[n+2] = ' '
-	buf.Write(buf.Tmp[:n+3])
+	buf.Tmp[n+1] = ' '
+	buf.Tmp[n+2] = ']'
+	buf.Tmp[n+3] = ' '
+	buf.Write(buf.Tmp[:n+4])
 }
 
 // SprintHeader formats a log header and returns a string. This is a simpler

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -115,6 +115,22 @@ func (buf *Buffer) someDigits(i, d int) int {
 // FormatHeader formats a log header using the provided file name and line number
 // and writes it into the buffer.
 func (buf *Buffer) FormatHeader(s severity.Severity, file string, line int, now time.Time) {
+	n := buf.FormatHeaderPre(s, file, line, now)
+	buf.Tmp[n+1] = ']'
+	buf.Tmp[n+2] = ' '
+	buf.Write(buf.Tmp[:n+3])
+}
+
+// FormatHeaderWithSpace add a space before and after 'filename:line number'. GoLand/VSCode will recognize it as a hyperlink
+func (buf *Buffer) FormatHeaderWithSpace(s severity.Severity, file string, line int, now time.Time) {
+	n := buf.FormatHeaderPre(s, file, line, now)
+	buf.Tmp[n+1] = ' '
+	buf.Tmp[n+2] = ']'
+	buf.Tmp[n+3] = ' '
+	buf.Write(buf.Tmp[:n+4])
+}
+
+func (buf *Buffer) FormatHeaderPre(s severity.Severity, file string, line int, now time.Time) int {
 	if line < 0 {
 		line = 0 // not a real line number, but acceptable to someDigits
 	}
@@ -148,10 +164,7 @@ func (buf *Buffer) FormatHeader(s severity.Severity, file string, line int, now 
 	buf.WriteString(file)
 	buf.Tmp[0] = ':'
 	n := buf.someDigits(1, line)
-	buf.Tmp[n+1] = ' '
-	buf.Tmp[n+2] = ']'
-	buf.Tmp[n+3] = ' '
-	buf.Write(buf.Tmp[:n+4])
+	return n
 }
 
 // SprintHeader formats a log header and returns a string. This is a simpler

--- a/klog.go
+++ b/klog.go
@@ -427,6 +427,7 @@ func init() {
 	commandLine.Var(&logging.verbosity, "v", "number for the log level verbosity")
 	commandLine.BoolVar(&logging.addDirHeader, "add_dir_header", false, "If true, adds the file directory to the header of the log messages")
 	commandLine.BoolVar(&logging.skipHeaders, "skip_headers", false, "If true, avoid header prefixes in the log messages")
+	commandLine.BoolVar(&logging.hyperlinkHeaders, "hyperlink_headers", false, "If true, will add a space before and after 'filename:line number'. GoLand/VSCode will recognize it as a hyperlink")
 	commandLine.BoolVar(&logging.oneOutput, "one_output", false, "If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)")
 	commandLine.BoolVar(&logging.skipLogHeaders, "skip_log_headers", false, "If true, avoid headers when opening log files (no effect when -logtostderr=true)")
 	logging.stderrThreshold = severityValue{
@@ -516,6 +517,9 @@ type settings struct {
 
 	// If true, do not add the prefix headers, useful when used with SetOutput
 	skipHeaders bool
+
+	// If true, will add a space before and after 'filename:line number'. GoLand/VSCode will recognize it as a hyperlink
+	hyperlinkHeaders bool
 
 	// If true, do not add the headers to log files
 	skipLogHeaders bool
@@ -679,6 +683,10 @@ func (l *loggingT) header(s severity.Severity, depth int) (*buffer.Buffer, strin
 func (l *loggingT) formatHeader(s severity.Severity, file string, line int, now time.Time) *buffer.Buffer {
 	buf := buffer.GetBuffer()
 	if l.skipHeaders {
+		return buf
+	}
+	if l.hyperlinkHeaders {
+		buf.FormatHeaderWithSpace(s, file, line, now)
 		return buf
 	}
 	buf.FormatHeader(s, file, line, now)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

To facilitate debugging and troubleshooting, it's often necessary to include detailed line number information in logs.
Ideally, these should be clickable, directing to the corresponding code location. 
To implement this feature, we just need to make the following configuration: add a space before and after "filename:line number" in the logs. GoLand/VSCode will then recognize it as a hyperlink.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implemented IDE file navigation feature in buffer.go
```