### PR TITLE
build: fix some linter warnings

### DIFF
--- a/contextual_slog_example_test.go
+++ b/contextual_slog_example_test.go
@@ -31,7 +31,7 @@ func ExampleSetSlogLogger() {
 	defer state.Restore()
 
 	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+		ReplaceAttr: func(_ /* groups */ []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				// Avoid non-deterministic output.
 				return slog.Attr{}

--- a/klogr/output_test.go
+++ b/klogr/output_test.go
@@ -30,7 +30,7 @@ import (
 func TestKlogrOutput(t *testing.T) {
 	test.InitKlog(t)
 	test.Output(t, test.OutputConfig{
-		NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
+		NewLogger: func(_ io.Writer, _ int, _ string) logr.Logger {
 			return klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog))
 		},
 	})

--- a/output_test.go
+++ b/output_test.go
@@ -41,7 +41,7 @@ func BenchmarkKlogOutput(b *testing.B) {
 
 // klogKlogrConfig tests klogr output via klog, using the klog/v2 klogr.
 var klogKLogrConfig = test.OutputConfig{
-	NewLogger: func(out io.Writer, v int, vmodule string) logr.Logger {
+	NewLogger: func(_ io.Writer, _ int, _ string) logr.Logger {
 		return klog.NewKlogr()
 	},
 }

--- a/test/output.go
+++ b/test/output.go
@@ -584,7 +584,7 @@ func Output(t *testing.T, config OutputConfig) {
 
 			if config.NewLogger == nil {
 				// Test klog.
-				testOutput(t, printWithKlogLine-1, func(buffer *bytes.Buffer) {
+				testOutput(t, printWithKlogLine-1, func(_ *bytes.Buffer) {
 					printWithKlog(test)
 				})
 				return

--- a/textlogger/textlogger_test.go
+++ b/textlogger/textlogger_test.go
@@ -82,7 +82,7 @@ func ExampleBacktrace() {
 	backtraceCounter := 0
 	config := textlogger.NewConfig(
 		textlogger.FixedTime(ts), // To get consistent output for each run.
-		textlogger.Backtrace(func(skip int) (filename string, line int) {
+		textlogger.Backtrace(func(_ /* skip */ int) (filename string, line int) {
 			backtraceCounter++
 			if backtraceCounter == 1 {
 				// Simulate "missing information".


### PR DESCRIPTION
**What this PR does / why we need it**:

revive in golangci-lint has version v1.56.2 complains about unused named parameters. Sometimes names are useful to document the purpose of a parameter. Comments are used instead now in those cases.

**Release note**:
```release-note
NONE
```

/assign @mengjiao-liu 