### PR TITLE
Do not acquire lock for file.Sync() fsync call

### DIFF
--- a/klog_test.go
+++ b/klog_test.go
@@ -546,7 +546,8 @@ func TestOpenAppendOnStart(t *testing.T) {
 	}
 
 	// ensure we wrote what we expected
-	logging.flushAll()
+	files := logging.flushAll()
+	logging.syncAll(files)
 	b, err := ioutil.ReadFile(logging.logFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -817,7 +818,8 @@ func BenchmarkLogs(b *testing.B) {
 		Warning("warning")
 		Info("info")
 	}
-	logging.flushAll()
+	files := logging.flushAll()
+	logging.syncAll(files)
 }
 
 // Test the logic on checking log size limitation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

For file.Sync() (the fsync system call that flushes the kernel buffer to disk), there is no need to acquire a lock; let the kernel handle it.

**Which issue(s) this PR fixes**:

Fixes #403 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not acquire lock for file.Sync() fsync call
```