### PR TITLE
examples: fix linter warning

### DIFF
--- a/examples/output_test/output_test.go
+++ b/examples/output_test/output_test.go
@@ -112,7 +112,7 @@ func TestKlogrStackZapr(t *testing.T) {
 		mapping[key] = value
 	}
 
-	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
+	newLogger := func(out io.Writer, v int, _ string) logr.Logger {
 		// Backend: zapr as configured in k8s.io/component-base/logs/json.
 		klog.SetLogger(newZaprLogger(out, v))
 
@@ -177,7 +177,7 @@ func TestKlogrInternalStackZapr(t *testing.T) {
 		mapping[key] = value
 	}
 
-	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {
+	newLogger := func(out io.Writer, v int, _ string) logr.Logger {
 		// Backend: zapr as configured in k8s.io/component-base/logs/json.
 		klog.SetLogger(newZaprLogger(out, v))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The newer golangci-lint enables a revive check by default:

    output_test/output_test.go:115:42: unused-parameter: parameter 'vmodule' seems to be unused, consider removing or renaming it as _ (revive)
	newLogger := func(out io.Writer, v int, vmodule string) logr.Logger {


**Release note**:
```release-note
NONE
```