### PR TITLE
Use strconv.AppendQuote instead of strconv.Quote for message formatting

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -809,12 +809,16 @@ func (l *loggingT) infoS(logger *logWriter, filter LogFilter, depth int, msg str
 // printS is called from infoS and errorS if logger is not specified.
 // set log severity by s
 func (l *loggingT) printS(err error, s severity.Severity, depth int, msg string, keysAndValues ...interface{}) {
-	// Only create a new buffer if we don't have one cached.
-	b := buffer.GetBuffer()
 	// The message is always quoted, even if it contains line breaks.
 	// If developers want multi-line output, they should use a small, fixed
 	// message and put the multi-line output into a value.
-	b.WriteString(strconv.Quote(msg))
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
+	// Only create a new buffer if we don't have one cached.
+	b := buffer.GetBuffer()
+	b.Write(qMsg)
+
 	if err != nil {
 		serialize.KVListFormat(&b.Buffer, "err", err)
 	}

--- a/klogr_slog.go
+++ b/klogr_slog.go
@@ -63,8 +63,12 @@ func slogOutput(file string, line int, now time.Time, err error, s severity.Seve
 	}
 
 	// See printS.
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
 	b := buffer.GetBuffer()
-	b.WriteString(strconv.Quote(msg))
+	b.Write(qMsg)
+
 	if err != nil {
 		serialize.KVListFormat(&b.Buffer, "err", err)
 	}

--- a/textlogger/textlogger.go
+++ b/textlogger/textlogger.go
@@ -114,6 +114,12 @@ func runtimeBacktrace(skip int) (string, int) {
 }
 
 func (l *tlogger) printWithInfos(file string, line int, now time.Time, err error, s severity.Severity, msg string, kvList []interface{}) {
+	// The message is always quoted, even if it contains line breaks.
+	// If developers want multi-line output, they should use a small, fixed
+	// message and put the multi-line output into a value.
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
 	// Only create a new buffer if we don't have one cached.
 	b := buffer.GetBuffer()
 	defer buffer.PutBuffer(b)
@@ -124,10 +130,8 @@ func (l *tlogger) printWithInfos(file string, line int, now time.Time, err error
 	}
 	b.FormatHeader(s, file, line, now)
 
-	// The message is always quoted, even if it contains line breaks.
-	// If developers want multi-line output, they should use a small, fixed
-	// message and put the multi-line output into a value.
-	b.WriteString(strconv.Quote(msg))
+	b.Write(qMsg)
+
 	if err != nil {
 		serialize.KVFormat(&b.Buffer, "err", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

I've noticed that we can reduce memory allocations during log message formatting by preallocating a fixed-size buffer and using `strconv.AppendQuote` instead of always dynamically allocate memory in `strconv.Quote`.

Size of the buffer - `1024` - is chosen arbitrarily, it's just looks like the size, which may be enough got >99% of the logs and not too big to be a memory concern for goroutine stack. For cases, when it won't be enough, `append` inside `strconv.AppendQuote` will reallocate it to heap, and all gains will be lost.

Another improvement is the reduced time we're holding the buffer taken from the pool by doing message quotation before getting the buffer from the pool. It's hard to estimate the effect of that, but it's definetely not worse.

In order to measure the effect, I've ran `go test -benchmem -run=^$ -bench ^BenchmarkKlogOutput$ k8s.io/klog/v2` before and after the change and got the following results:

NAME | BEFORE | BEFORE | AFTER | AFTER |
-- | -- | -- | -- | --
BenchmarkKlogOutput/call_depth-16 | 352 B/op | 7 allocs/op | 336 B/op | 6 allocs/op
BenchmarkKlogOutput/cyclic_list-16 | 686 B/op | 11 allocs/op | 675 B/op | 10 allocs/op
BenchmarkKlogOutput/empty_WithValues-16 | 280 B/op | 5 allocs/op | 272 B/op | 4 allocs/op
BenchmarkKlogOutput/Error()_for_nil-16 | 793 B/op | 10 allocs/op | 777 B/op | 9 allocs/op
BenchmarkKlogOutput/Error()_that_panics-16 | 408 B/op | 7 allocs/op | 392 B/op | 6 allocs/op
BenchmarkKlogOutput/handle_integer_keys-16 | 761 B/op | 15 allocs/op | 737 B/op | 14 allocs/op
BenchmarkKlogOutput/handle_odd-numbers_of_Kvs_in_both_log_values_and_Info_args-16 | 825 B/op | 14 allocs/op | 809 B/op | 13 allocs/op
BenchmarkKlogOutput/handle_odd-numbers_of_KVs-16 | 416 B/op | 8 allocs/op | 392 B/op | 7 allocs/op
BenchmarkKlogOutput/html_characters-16 | 344 B/op | 8 allocs/op | 336 B/op | 7 allocs/op
BenchmarkKlogOutput/ignore_MarshalJSON-16 | 344 B/op | 7 allocs/op | 336 B/op | 6 allocs/op
BenchmarkKlogOutput/klog.Format-16 | 641 B/op | 14 allocs/op | 625 B/op | 13 allocs/op
BenchmarkKlogOutput/KObj-16 | 336 B/op | 6 allocs/op | 328 B/op | 5 allocs/op
BenchmarkKlogOutput/KObjs-16 | 416 B/op | 6 allocs/op | 408 B/op | 5 allocs/op
BenchmarkKlogOutput/KObjSlice_int_arg-16 | 368 B/op | 6 allocs/op | 360 B/op | 5 allocs/op
BenchmarkKlogOutput/KObjSlice_ints-16 | 408 B/op | 7 allocs/op | 400 B/op | 6 allocs/op
BenchmarkKlogOutput/KObjSlice_nil_arg-16 | 320 B/op | 6 allocs/op | 312 B/op | 5 allocs/op
BenchmarkKlogOutput/KObjSlice_nil_entry-16 | 352 B/op | 6 allocs/op | 344 B/op | 5 allocs/op
BenchmarkKlogOutput/KObjSlice_okay-16 | 376 B/op | 6 allocs/op | 360 B/op | 5 allocs/op
BenchmarkKlogOutput/log_with_multiple_names_and_values-16 | 512 B/op | 12 allocs/op | 504 B/op | 11 allocs/op
BenchmarkKlogOutput/log_with_name_and_values-16 | 480 B/op | 12 allocs/op | 472 B/op | 11 allocs/op
BenchmarkKlogOutput/log_with_values-16 | 344 B/op | 7 allocs/op | 336 B/op | 6 allocs/op
BenchmarkKlogOutput/map_keys-16 | 456 B/op | 11 allocs/op | 440 B/op | 10 allocs/op
BenchmarkKlogOutput/map_values-16 | 577 B/op | 14 allocs/op | 569 B/op | 13 allocs/op
BenchmarkKlogOutput/MarshalLog()_for_nil-16 | 560 B/op | 8 allocs/op | 536 B/op | 7 allocs/op
BenchmarkKlogOutput/MarshalLog()_that_panics-16 | 480 B/op | 9 allocs/op | 456 B/op | 8 allocs/op
BenchmarkKlogOutput/MarshalLog()_that_returns_itself-16 | 360 B/op | 6 allocs/op | 328 B/op | 5 allocs/op
BenchmarkKlogOutput/multiple_WithValues-16 | 1811 B/op | 30 allocs/op | 1779 B/op | 26 allocs/op
BenchmarkKlogOutput/odd_WithValues-16 | 1474 B/op | 27 allocs/op | 1402 B/op | 24 allocs/op
BenchmarkKlogOutput/other_vmodule-16 | 0 B/op | 0 allocs/op | 0 B/op | 0 allocs/op
BenchmarkKlogOutput/override_single_value-16 | 344 B/op | 7 allocs/op | 336 B/op | 6 allocs/op
BenchmarkKlogOutput/override_WithValues-16 | 512 B/op | 14 allocs/op | 512 B/op | 13 allocs/op
BenchmarkKlogOutput/preserve_order_of_key/value_pairs-16 | 961 B/op | 15 allocs/op | 953 B/op | 14 allocs/op
BenchmarkKlogOutput/print_duplicate_keys_in_arguments-16 | 416 B/op | 8 allocs/op | 408 B/op | 7 allocs/op
BenchmarkKlogOutput/quotation-16 | 384 B/op | 7 allocs/op | 368 B/op | 6 allocs/op
BenchmarkKlogOutput/regular_error_types_as_value-16 | 344 B/op | 7 allocs/op | 336 B/op | 6 allocs/op
BenchmarkKlogOutput/regular_error_types_when_using_logr.Error-16 | 312 B/op | 6 allocs/op | 304 B/op | 5 allocs/op
BenchmarkKlogOutput/slice_values-16 | 392 B/op | 6 allocs/op | 376 B/op | 5 allocs/op
BenchmarkKlogOutput/String()_for_nil-16 | 849 B/op | 11 allocs/op | 825 B/op | 10 allocs/op
BenchmarkKlogOutput/String()_that_panics-16 | 464 B/op | 8 allocs/op | 440 B/op | 7 allocs/op
BenchmarkKlogOutput/struct_keys-16 | 680 B/op | 14 allocs/op | 664 B/op | 13 allocs/op
BenchmarkKlogOutput/struct_values-16 | 360 B/op | 6 allocs/op | 344 B/op | 5 allocs/op
BenchmarkKlogOutput/verbosity_disabled-16 | 0 B/op | 0 allocs/op | 0 B/op | 0 allocs/op
BenchmarkKlogOutput/verbosity_enabled-16 | 296 B/op | 5 allocs/op | 280 B/op | 4 allocs/op
BenchmarkKlogOutput/vmodule-16 | 440 B/op | 6 allocs/op | 312 B/op | 4 allocs/op



**Special notes for your reviewer**:


**Release note**:
```release-note
Reduce memory allocations for log messages shorter than 1024 bytes.
```