### PR TITLE
Remove old note on Go version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ How to use klog
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 - See our documentation on [pkg.go.dev/k8s.io](https://pkg.go.dev/k8s.io/klog).
 
-**NOTE**: please use the newer go versions that support semantic import versioning in modules, ideally go 1.11.4 or greater.
-
 ### Coexisting with klog/v2
 
 See [this example](examples/coexist_klog_v1_and_v2/) to see how to coexist with both klog/v1 and klog/v2.


### PR DESCRIPTION
Removed old note about using newer Go versions for semantic import versioning.
