### PR TITLE
test with 1.24 and 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ["1.21", "1.22", "1.23"]
+        go-version: ["1.21", "1.22", "1.23", "1.24", "1.25"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/klogr_slog_test.go
+++ b/klogr_slog_test.go
@@ -43,7 +43,7 @@ func (c coordinates) LogValue() slog.Value {
 	return slog.GroupValue(slog.Attr{Key: "X", Value: slog.IntValue(c.x)}, slog.Attr{Key: "Y", Value: slog.IntValue(c.y)})
 }
 
-func ExampleBackground_Slog() {
+func ExampleBackground_slog() {
 	// Temporarily reconfigure for output to stdout, with -v=4.
 	state := klog.CaptureState()
 	defer state.Restore()

--- a/textlogger/textlogger_slog_test.go
+++ b/textlogger/textlogger_slog_test.go
@@ -40,7 +40,7 @@ func (c coordinates) LogValue() slog.Value {
 	return slog.GroupValue(slog.Attr{Key: "X", Value: slog.IntValue(c.x)}, slog.Attr{Key: "Y", Value: slog.IntValue(c.y)})
 }
 
-func ExampleNewLogger_Slog() {
+func ExampleNewLogger_slog() {
 	ts, _ := time.Parse(time.RFC3339, "2000-12-24T12:30:40Z")
 	internal.Pid = 123 // To get consistent output for each run.
 	config := textlogger.NewConfig(


### PR DESCRIPTION
**What this PR does / why we need it**:

More recent "go vet" no longer accepts _Slog as suffix for an example, which matches the documented "must start with a lower-case letter" (https://pkg.go.dev/testing#hdr-Examples).


**Release note**:
```release-note
NONE
```
