### PR TITLE
fix: apply gofmt formatting to package doc comment in klog.go

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -56,53 +56,53 @@
 // This package provides several flags that modify this behavior.
 // As a result, flag.Parse must be called before any logging is done.
 //
-//		-logtostderr=true
-//			Logs are written to standard error instead of to files.
-//	             By default, all logs are written regardless of severity
-//	             (legacy behavior). To filter logs by severity when
-//	             -logtostderr=true, set -legacy_stderr_threshold_behavior=false
-//	             and use -stderrthreshold.
-//              With -legacy_stderr_threshold_behavior=true,
-//              -stderrthreshold has no effect.
+//	-logtostderr=true
+//		Logs are written to standard error instead of to files.
+//		By default, all logs are written regardless of severity
+//		(legacy behavior). To filter logs by severity when
+//		-logtostderr=true, set -legacy_stderr_threshold_behavior=false
+//		and use -stderrthreshold.
+//		With -legacy_stderr_threshold_behavior=true,
+//		-stderrthreshold has no effect.
 //
-//	             The following flags always have no effect:
-//	             -alsologtostderr, -alsologtostderrthreshold, and -log_dir.
-//	             Output redirection at runtime with SetOutput is also ignored.
-//		-alsologtostderr=false
-//			Logs are written to standard error as well as to files.
-//		-alsologtostderrthreshold=INFO
-//			Log events at or above this severity are logged to standard
-//			error when -alsologtostderr=true (no effect when -logtostderr=true).
-//			Default is INFO to maintain backward compatibility.
-//		-stderrthreshold=ERROR
-//			Log events at or above this severity are logged to standard
-//			error as well as to files. When -logtostderr=true, this flag
-//			has no effect unless -legacy_stderr_threshold_behavior=false.
-//		-legacy_stderr_threshold_behavior=true
-//			If true, -stderrthreshold is ignored when -logtostderr=true
-//			(legacy behavior). If false, -stderrthreshold is honored even
-//			when -logtostderr=true, allowing severity-based filtering.
-//		-log_dir=""
-//			Log files will be written to this directory instead of the
-//			default temporary directory.
+//		The following flags always have no effect:
+//		-alsologtostderr, -alsologtostderrthreshold, and -log_dir.
+//		Output redirection at runtime with SetOutput is also ignored.
+//	-alsologtostderr=false
+//		Logs are written to standard error as well as to files.
+//	-alsologtostderrthreshold=INFO
+//		Log events at or above this severity are logged to standard
+//		error when -alsologtostderr=true (no effect when -logtostderr=true).
+//		Default is INFO to maintain backward compatibility.
+//	-stderrthreshold=ERROR
+//		Log events at or above this severity are logged to standard
+//		error as well as to files. When -logtostderr=true, this flag
+//		has no effect unless -legacy_stderr_threshold_behavior=false.
+//	-legacy_stderr_threshold_behavior=true
+//		If true, -stderrthreshold is ignored when -logtostderr=true
+//		(legacy behavior). If false, -stderrthreshold is honored even
+//		when -logtostderr=true, allowing severity-based filtering.
+//	-log_dir=""
+//		Log files will be written to this directory instead of the
+//		default temporary directory.
 //
-//		Other flags provide aids to debugging.
+//	Other flags provide aids to debugging.
 //
-//		-log_backtrace_at=""
-//			When set to a file and line number holding a logging statement,
-//			such as
-//				-log_backtrace_at=gopherflakes.go:234
-//			a stack trace will be written to the Info log whenever execution
-//			hits that statement. (Unlike with -vmodule, the ".go" must be
-//			present.)
-//		-v=0
-//			Enable V-leveled logging at the specified level.
-//		-vmodule=""
-//			The syntax of the argument is a comma-separated list of pattern=N,
-//			where pattern is a literal file name (minus the ".go" suffix) or
-//			"glob" pattern and N is a V level. For instance,
-//				-vmodule=gopher*=3
-//			sets the V level to 3 in all Go files whose names begin "gopher".
+//	-log_backtrace_at=""
+//		When set to a file and line number holding a logging statement,
+//		such as
+//			-log_backtrace_at=gopherflakes.go:234
+//		a stack trace will be written to the Info log whenever execution
+//		hits that statement. (Unlike with -vmodule, the ".go" must be
+//		present.)
+//	-v=0
+//		Enable V-leveled logging at the specified level.
+//	-vmodule=""
+//		The syntax of the argument is a comma-separated list of pattern=N,
+//		where pattern is a literal file name (minus the ".go" suffix) or
+//		"glob" pattern and N is a V level. For instance,
+//			-vmodule=gopher*=3
+//		sets the V level to 3 in all Go files whose names begin "gopher".
 package klog
 
 import (


### PR DESCRIPTION
## Summary

Fix mixed tab/space indentation in the package doc comment of `klog.go` (lines 59-105) introduced by #432, which caused the `golangci-lint` gofmt check to fail in CI.

To prevent this from happening again, a separate PR has been submitted to add lint as a required status check in Prow branch protection: [kubernetes/test-infra#36671](https://github.com/kubernetes/test-infra/pull/36671).

## Root cause

See [root cause analysis comment](https://github.com/kubernetes/klog/pull/435#issuecomment-4073141482) for details on why PR #432's pipeline didn't catch the formatting error.

## Test plan

- [x] `gofmt -d klog.go` shows no diff
- [x] `go build ./...` compiles successfully